### PR TITLE
fix: prevent Husky installation during Docker production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN npm run build
 RUN npm run extract:contracts:standalone
 RUN npm run generate:openapi
 
-RUN npm ci --only=production && npm cache clean --force
+RUN NODE_ENV=production npm ci --only=production && npm cache clean --force
 
 RUN npx prisma generate
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "generate:cli": "ts-node -r tsconfig-paths/register tools/generators/cli-generator.ts",
     "generate:n8n": "ts-node -r tsconfig-paths/register tools/generators/n8n-generator.ts",
     "generate:openapi": "ts-node -r tsconfig-paths/register tools/generators/openapi-generator.ts",
-    "prepare": "husky"
+    "prepare": "[ \"$NODE_ENV\" = \"production\" ] || husky || true"
   },
   "dependencies": {
     "@nestjs/bullmq": "^11.0.3",


### PR DESCRIPTION
## Summary

- Fixed Docker build failure caused by Husky prepare script running during production install
- Modified prepare script to conditionally skip Husky when NODE_ENV=production
- Updated Dockerfile to set NODE_ENV=production during npm ci --only=production

## Problem

The Docker build was failing because the `prepare` script attempted to run `husky` during production dependency installation, but Husky is a devDependency and not available in the production build context.

## Solution

- **package.json**: Changed prepare script from `"husky"` to `"[ \"$NODE_ENV\" = \"production\" ] || husky || true"`
- **Dockerfile**: Added `NODE_ENV=production` to the npm ci command

## Test plan

- [x] Docker build completes successfully without Husky errors
- [x] Husky still works in development environment (when NODE_ENV ≠ production)
- [x] Production build properly skips Git hooks installation

🤖 Generated with [Claude Code](https://claude.ai/code)