### PR TITLE
fix: resolve WhatsApp connection status race condition

### DIFF
--- a/src/platforms/providers/whatsapp.provider.spec.ts
+++ b/src/platforms/providers/whatsapp.provider.spec.ts
@@ -156,8 +156,8 @@ describe('WhatsAppProvider', () => {
       );
       expect(adapter2).toBe(provider);
 
-      // Should only call Evolution API once
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      // Should call Evolution API twice (webhook setup + connection status check)
+      expect(global.fetch).toHaveBeenCalledTimes(2);
     });
 
     it('should cleanup connection on adapter creation failure', async () => {
@@ -371,8 +371,11 @@ describe('WhatsAppProvider', () => {
       };
 
       // Connection exists but not connected
-      const result = await provider.sendMessage(envelope, { text: 'reply' });
-      expect(result.providerMessageId).toBe('whatsapp-evo-not-connected');
+      await expect(
+        provider.sendMessage(envelope, { text: 'reply' }),
+      ).rejects.toThrow(
+        'WhatsApp not connected for project1:platform1, cannot send message',
+      );
     });
 
     it('should handle Evolution API send message failure', async () => {
@@ -404,8 +407,9 @@ describe('WhatsAppProvider', () => {
         provider: { raw: { platformId: 'platform1' } },
       };
 
-      const result = await provider.sendMessage(envelope, { text: 'reply' });
-      expect(result.providerMessageId).toBe('whatsapp-evo-send-failed');
+      await expect(
+        provider.sendMessage(envelope, { text: 'reply' }),
+      ).rejects.toThrow('Evolution API error: Rate Limited');
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes the race condition where WhatsApp messages would fail immediately after connection creation with misleading "success" logs.

- **Root Cause**: Connections were created with `isConnected: false` and only updated via webhooks, but messages were being sent immediately after adapter creation before webhook events arrived
- **Race Condition**: Message processor would get "WhatsApp not connected" warning but log it as successful due to fake return values  
- **Misleading Logs**: Provider returned fake success responses (`whatsapp-evo-not-connected`) instead of proper exceptions

## Key Changes

### ✅ **Connection Status Detection**
- Added `refreshConnectionStatus()` method to check actual Evolution API status during adapter creation
- Now properly detects when Evolution API instance is already connected (`connectionStatus: "open"`)
- Eliminates the gap between connection creation and webhook-based status updates

### ✅ **Proper Error Handling** 
- Replace fake success returns with proper exceptions in `sendMessage()`
- Connection failures now throw errors instead of returning fake provider message IDs
- Message processor will now correctly handle failures and mark them for retry

### ✅ **Eliminates Race Condition**
- Connection status is checked immediately after webhook setup
- Messages sent right after adapter creation will see correct connection state
- No more false "not connected" errors for actually connected instances

## Test Results

Tested with live Evolution API instance:
- ✅ Evolution API shows `connectionStatus: "open"` 
- ✅ Connection properly detected as connected during adapter creation
- ✅ Messages can be sent immediately after connection setup
- ✅ No more misleading success logs for failed connections

## Technical Details

**Before:**
```typescript
// Always created with isConnected: false
const connection = { isConnected: false, connectionState: 'close' };
// Only updated later via webhook events
```

**After:**  
```typescript
await this.setupWebhook(connection, credentials.webhookToken);
await this.refreshConnectionStatus(connection); // NEW: Check actual status
// Now isConnected reflects reality immediately
```

🤖 Generated with [Claude Code](https://claude.ai/code)