### PR TITLE
fix: allow multiple targets per message job

### DIFF
--- a/prisma/migrations/20250928220500_fix_sent_message_multi_target_constraint/migration.sql
+++ b/prisma/migrations/20250928220500_fix_sent_message_multi_target_constraint/migration.sql
@@ -1,0 +1,8 @@
+-- DropIndex
+DROP INDEX "public"."sent_messages_job_id_key";
+
+-- CreateIndex
+CREATE INDEX "sent_messages_job_id_idx" ON "public"."sent_messages"("job_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sent_messages_job_id_platform_id_target_chat_id_key" ON "public"."sent_messages"("job_id", "platform_id", "target_chat_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -205,13 +205,14 @@ model SentMessage {
   project           Project          @relation(fields: [projectId], references: [id], onDelete: Cascade)
   platformConfig    ProjectPlatform  @relation(fields: [platformId], references: [id], onDelete: Cascade)
 
-  @@unique([jobId])
+  @@unique([jobId, platformId, targetChatId])
   @@index([projectId])
   @@index([platformId])
   @@index([status])
   @@index([createdAt])
   @@index([targetChatId])
   @@index([targetUserId])
+  @@index([jobId])
   @@map("sent_messages")
 }
 


### PR DESCRIPTION
## Summary
- Fixes unique constraint error when sending messages to multiple targets (Discord + WhatsApp, etc.)
- Replaces single `job_id` unique constraint with composite constraint on `(job_id, platform_id, target_chat_id)`
- Allows multiple `SentMessage` records per job while preventing duplicates

## Problem
Messages to multiple targets were failing with:
```
Unique constraint failed on the fields: (job_id)
```

## Solution
- Database schema change: `@@unique([jobId])` → `@@unique([jobId, platformId, targetChatId])`
- Migration created to safely apply in production
- Maintains data integrity while enabling multi-target messaging

## Test Plan
- [x] Schema migration created and tested locally
- [x] Deploy to production and test multi-target messaging
- [x] Verify WhatsApp + Discord simultaneous delivery works

🤖 Generated with [Claude Code](https://claude.ai/code)