### PR TITLE
fix: platform providers return fake success on errors instead of throwing

### DIFF
--- a/src/platforms/providers/discord.provider.spec.ts
+++ b/src/platforms/providers/discord.provider.spec.ts
@@ -122,17 +122,16 @@ describe('DiscordProvider', () => {
         provider: { eventId: 'event2', raw: { platformId: 'platform-2' } },
       } as any;
 
-      // Both should return not-ready since no connections are set up
-      const results = await Promise.all([
+      // All should throw errors since no connections are set up
+      await expect(
         provider.sendMessage(env1, { text: 'Hello 1' }),
+      ).rejects.toThrow('Discord client not ready');
+      await expect(
         provider.sendMessage(env2, { text: 'Hello 2' }),
+      ).rejects.toThrow('Discord client not ready');
+      await expect(
         provider.sendMessage(env1, { text: 'Hello 1 again' }),
-      ]);
-
-      // Verify isolation - each should have consistent responses (no connections set up)
-      expect(results[0].providerMessageId).toBe('discord-not-ready');
-      expect(results[1].providerMessageId).toBe('discord-not-ready');
-      expect(results[2].providerMessageId).toBe('discord-not-ready');
+      ).rejects.toThrow('Discord client not ready');
     });
   });
 
@@ -550,9 +549,9 @@ describe('DiscordProvider', () => {
         },
       } as any;
 
-      const result = await provider.sendMessage(envelope, {});
-
-      expect(result.providerMessageId).toBe('discord-send-failed');
+      await expect(provider.sendMessage(envelope, {})).rejects.toThrow(
+        'Message must have text or attachments',
+      );
       expect(mockChannel.send).not.toHaveBeenCalled();
     });
 

--- a/src/platforms/providers/discord.provider.ts
+++ b/src/platforms/providers/discord.provider.ts
@@ -433,17 +433,16 @@ export class DiscordProvider
     const platformId = (env.provider?.raw as any)?.platformId;
     if (!platformId) {
       this.logger.error('No platformId in envelope, cannot route message');
-      return { providerMessageId: 'discord-no-platform-id' };
+      throw new Error('No platformId in envelope, cannot route message');
     }
 
     const connectionKey = `${env.projectId}:${platformId}`;
     const connection = this.connections.get(connectionKey);
 
     if (!connection || !connection.client.isReady()) {
-      this.logger.warn(
+      throw new Error(
         `Discord client not ready for ${connectionKey}, cannot send message`,
       );
-      return { providerMessageId: 'discord-not-ready' };
     }
 
     try {
@@ -524,7 +523,7 @@ export class DiscordProvider
         `Failed to send Discord message to ${env.threadId}:`,
         error.message,
       );
-      return { providerMessageId: 'discord-send-failed' };
+      throw error; // Re-throw to propagate error to processor
     }
   }
 

--- a/src/platforms/providers/telegram.provider.spec.ts
+++ b/src/platforms/providers/telegram.provider.spec.ts
@@ -232,9 +232,9 @@ describe('TelegramProvider', () => {
         provider: { raw: { platformId } },
       } as any;
 
-      const result = await provider.sendMessage(envelope, { text: 'Hello!' });
-
-      expect(result.providerMessageId).toBe('telegram-not-ready');
+      await expect(
+        provider.sendMessage(envelope, { text: 'Hello!' }),
+      ).rejects.toThrow('Telegram bot not ready');
     });
   });
 
@@ -532,16 +532,16 @@ describe('TelegramProvider', () => {
 
       mockBot.sendPhoto.mockRejectedValue(new Error('File too large'));
 
-      const result = await provider.sendMessage(envelope, {
-        attachments: [
-          {
-            url: 'https://example.com/large-image.png',
-            mimeType: 'image/png',
-          },
-        ],
-      });
-
-      expect(result.providerMessageId).toBe('telegram-send-failed');
+      await expect(
+        provider.sendMessage(envelope, {
+          attachments: [
+            {
+              url: 'https://example.com/large-image.png',
+              mimeType: 'image/png',
+            },
+          ],
+        }),
+      ).rejects.toThrow('File too large');
     });
   });
 });

--- a/src/platforms/providers/telegram.provider.ts
+++ b/src/platforms/providers/telegram.provider.ts
@@ -558,17 +558,16 @@ export class TelegramProvider implements PlatformProvider, PlatformAdapter {
     const platformId = (env.provider?.raw as any)?.platformId;
     if (!platformId) {
       this.logger.error('No platformId in envelope, cannot route message');
-      return { providerMessageId: 'telegram-no-platform-id' };
+      throw new Error('No platformId in envelope, cannot route message');
     }
 
     const connectionKey = `${env.projectId}:${platformId}`;
     const connection = this.connections.get(connectionKey);
 
     if (!connection || !connection.isActive) {
-      this.logger.warn(
+      throw new Error(
         `Telegram bot not ready for ${connectionKey}, cannot send message`,
       );
-      return { providerMessageId: 'telegram-not-ready' };
     }
 
     try {
@@ -641,7 +640,7 @@ export class TelegramProvider implements PlatformProvider, PlatformAdapter {
       );
 
       this.logger.error('Failed to send Telegram message:', error.message);
-      return { providerMessageId: 'telegram-send-failed' };
+      throw error; // Re-throw to propagate error to processor
     }
   }
 

--- a/src/platforms/providers/whatsapp.provider.spec.ts
+++ b/src/platforms/providers/whatsapp.provider.spec.ts
@@ -350,8 +350,9 @@ describe('WhatsAppProvider', () => {
         provider: { raw: {} }, // Missing platformId
       };
 
-      const result = await provider.sendMessage(envelope, { text: 'reply' });
-      expect(result.providerMessageId).toBe('whatsapp-evo-no-platform-id');
+      await expect(
+        provider.sendMessage(envelope, { text: 'reply' }),
+      ).rejects.toThrow('No platformId in envelope, cannot route message');
     });
 
     it('should handle sending to disconnected instance', async () => {

--- a/src/platforms/providers/whatsapp.provider.ts
+++ b/src/platforms/providers/whatsapp.provider.ts
@@ -708,7 +708,7 @@ export class WhatsAppProvider implements PlatformProvider, PlatformAdapter {
     const platformId = (env.provider?.raw as any)?.platformId;
     if (!platformId) {
       this.logger.error('No platformId in envelope, cannot route message');
-      return { providerMessageId: 'whatsapp-evo-no-platform-id' };
+      throw new Error('No platformId in envelope, cannot route message');
     }
 
     const connectionKey = `${env.projectId}:${platformId}`;


### PR DESCRIPTION
## 🐛 Critical Bug Fix

Platform providers were silently failing but reporting success, causing messages to be marked as "sent" when they actually failed.

## 🔍 Root Cause

Providers returned fake success indicators instead of throwing errors:
- Discord: `discord-no-platform-id`, `discord-not-ready`, `discord-send-failed`
- Telegram: `telegram-no-platform-id`, `telegram-not-ready`, `telegram-send-failed`
- WhatsApp: `whatsapp-evo-no-platform-id`

## 💥 Impact

1. ❌ Messages incorrectly marked as "sent" when delivery failed
2. ❌ Wrong webhook events fired (`message.sent` instead of `message.failed`)
3. ❌ Retry mechanisms never triggered
4. ❌ No visibility into actual delivery failures
5. ❌ Inaccurate delivery statistics

## ✅ Fix Applied

Changed all error paths to throw proper errors:

### Discord Provider (`discord.provider.ts`)
- Lines 432-446: Throw on missing platformId and not-ready states
- Lines 521-527: Re-throw catch block errors

### Telegram Provider (`telegram.provider.ts`)
- Lines 557-571: Throw on missing platformId and not-ready states
- Lines 642-644: Re-throw catch block errors

### WhatsApp Provider (`whatsapp.provider.ts`)
- Lines 708-712: Throw on missing platformId
- Catch block already correct

### Test Updates
Updated 5 tests to expect error throws instead of fake success responses

## 🧪 Verification

✅ All 544 tests passing with proper error propagation  
✅ Real-world test confirmed: Messages now show status `"failed"` with error message instead of fake `"sent"` status

### Before Fix:
```json
{
  "status": "sent",
  "providerMessageId": "discord-send-failed",
  "errorMessage": null
}
```

### After Fix:
```json
{
  "status": "failed",
  "providerMessageId": null,
  "errorMessage": "Missing Permissions"
}
```

## 📊 Results

Now the system correctly:
- ✅ Tracks accurate message status
- ✅ Shows visible error messages for debugging
- ✅ Fires correct webhook events (`message.failed`)
- ✅ Enables retry mechanisms to work properly
- ✅ Reports accurate delivery statistics