### PR TITLE
refactor: migrate from slug-based to ID-based project routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ GateKit implements **defense-in-depth security** with multiple overlapping layer
 **Layer 2: Service-Level Validation (Defense-in-Depth)**
 
 ```typescript
-SecurityUtil.getProjectWithAccess(prisma, projectSlug, authContext, operation);
+SecurityUtil.getProjectWithAccess(prisma, projectId, authContext, operation);
 ```
 
 - Mandatory validation at service level prevents bypass scenarios
@@ -110,36 +110,36 @@ authContext: AuthContext; // Required, not optional
 - `GET /api/v1/health` - Public health check
 - `POST /api/v1/projects` - Create project
 - `GET /api/v1/projects` - List all projects
-- `GET /api/v1/projects/:slug` - Get project details
-- `PATCH /api/v1/projects/:slug` - Update project
-- `DELETE /api/v1/projects/:slug` - Delete project
-- `POST /api/v1/projects/:slug/keys` - Generate API key
-- `GET /api/v1/projects/:slug/keys` - List API keys
-- `DELETE /api/v1/projects/:slug/keys/:keyId` - Revoke key
-- `POST /api/v1/projects/:slug/keys/:keyId/roll` - Roll key
+- `GET /api/v1/projects/:id` - Get project details
+- `PATCH /api/v1/projects/:id` - Update project
+- `DELETE /api/v1/projects/:id` - Delete project
+- `POST /api/v1/projects/:id/keys` - Generate API key
+- `GET /api/v1/projects/:id/keys` - List API keys
+- `DELETE /api/v1/projects/:id/keys/:keyId` - Revoke key
+- `POST /api/v1/projects/:id/keys/:keyId/roll` - Roll key
 
 ### Platform Configuration
 
-- `GET /api/v1/projects/:slug/platforms` - List configured platforms
-- `POST /api/v1/projects/:slug/platforms` - Configure platform (Discord, Telegram, WhatsApp-Evo)
-- `PATCH /api/v1/projects/:slug/platforms/:id` - Update platform
-- `DELETE /api/v1/projects/:slug/platforms/:id` - Delete platform
-- `POST /api/v1/projects/:slug/platforms/:id/register-webhook` - Register webhook with provider
-- `GET /api/v1/projects/:slug/platforms/:id/qr-code` - Get QR code for WhatsApp authentication
+- `GET /api/v1/projects/:id/platforms` - List configured platforms
+- `POST /api/v1/projects/:id/platforms` - Configure platform (Discord, Telegram, WhatsApp-Evo)
+- `PATCH /api/v1/projects/:id/platforms/:id` - Update platform
+- `DELETE /api/v1/projects/:id/platforms/:id` - Delete platform
+- `POST /api/v1/projects/:id/platforms/:id/register-webhook` - Register webhook with provider
+- `GET /api/v1/projects/:id/platforms/:id/qr-code` - Get QR code for WhatsApp authentication
 
 ### Messaging (Queue-based)
 
-- `POST /api/v1/projects/:slug/messages/send` - Queue message for delivery
-- `GET /api/v1/projects/:slug/messages/status/:jobId` - Check message status
-- `GET /api/v1/projects/:slug/messages/queue/metrics` - Queue metrics
-- `POST /api/v1/projects/:slug/messages/retry/:jobId` - Retry failed message
+- `POST /api/v1/projects/:id/messages/send` - Queue message for delivery
+- `GET /api/v1/projects/:id/messages/status/:jobId` - Check message status
+- `GET /api/v1/projects/:id/messages/queue/metrics` - Queue metrics
+- `POST /api/v1/projects/:id/messages/retry/:jobId` - Retry failed message
 
 ### Message Reception & Storage
 
-- `GET /api/v1/projects/:slug/messages` - List received messages with filtering
-- `GET /api/v1/projects/:slug/messages/stats` - Get message statistics
-- `GET /api/v1/projects/:slug/messages/:messageId` - Get specific message
-- `DELETE /api/v1/projects/:slug/messages/cleanup` - Delete old messages
+- `GET /api/v1/projects/:id/messages` - List received messages with filtering
+- `GET /api/v1/projects/:id/messages/stats` - Get message statistics
+- `GET /api/v1/projects/:id/messages/:messageId` - Get specific message
+- `DELETE /api/v1/projects/:id/messages/cleanup` - Delete old messages
 
 ### Platform Webhooks (Incoming - Dynamic & UUID-secured)
 
@@ -150,12 +150,12 @@ authContext: AuthContext; // Required, not optional
 
 ### Webhook Notifications (Outgoing - Event Subscriptions)
 
-- `POST /api/v1/projects/:slug/webhooks` - Create webhook subscription
-- `GET /api/v1/projects/:slug/webhooks` - List webhook subscriptions
-- `GET /api/v1/projects/:slug/webhooks/:webhookId` - Get webhook details with stats
-- `PATCH /api/v1/projects/:slug/webhooks/:webhookId` - Update webhook
-- `DELETE /api/v1/projects/:slug/webhooks/:webhookId` - Delete webhook
-- `GET /api/v1/projects/:slug/webhooks/:webhookId/deliveries` - List delivery attempts
+- `POST /api/v1/projects/:id/webhooks` - Create webhook subscription
+- `GET /api/v1/projects/:id/webhooks` - List webhook subscriptions
+- `GET /api/v1/projects/:id/webhooks/:webhookId` - Get webhook details with stats
+- `PATCH /api/v1/projects/:id/webhooks/:webhookId` - Update webhook
+- `DELETE /api/v1/projects/:id/webhooks/:webhookId` - Delete webhook
+- `GET /api/v1/projects/:id/webhooks/:webhookId/deliveries` - List delivery attempts
 
 ## Platform Integrations
 
@@ -293,7 +293,7 @@ Central utility for all security operations with zero-duplication patterns:
 // Get project and validate access in one step
 const project = await SecurityUtil.getProjectWithAccess(
   prisma,
-  projectSlug,
+  projectId,
   authContext,
   'operation',
 );
@@ -312,7 +312,7 @@ Type-safe authentication context passed between layers:
 ```typescript
 interface AuthContext {
   authType: 'api-key' | 'jwt';
-  project?: { id: string; slug: string };
+  project?: { id: string };
   user?: { userId: string; email?: string };
 }
 ```
@@ -324,7 +324,7 @@ interface AuthContext {
 @AuthContextParam() authContext: AuthContext
 
 // Service method signature
-async method(projectSlug: string, data: any, authContext: AuthContext)
+async method(projectId: string, data: any, authContext: AuthContext)
 ```
 
 #### **Error Handling**
@@ -415,11 +415,11 @@ When writing tests for services with project access:
 // REQUIRED: All service tests must provide auth context
 const mockAuthContext = {
   authType: 'api-key' as const,
-  project: { id: 'project-id', slug: 'test-project' },
+  project: { id: 'project-id' },
 };
 
 // Service call with auth context
-await service.method(projectSlug, data, mockAuthContext);
+await service.method(projectId, data, mockAuthContext);
 ```
 
 For detailed testing guidelines, see: **[test/CLAUDE.md](test/CLAUDE.md)**

--- a/README.md
+++ b/README.md
@@ -100,39 +100,39 @@ class YourAIAgent {
 # Project Management
 GET    /api/v1/projects                    # List projects
 POST   /api/v1/projects                    # Create project
-PATCH  /api/v1/projects/:slug              # Update project
+PATCH  /api/v1/projects/:id              # Update project
 
 # Team Management
-GET    /api/v1/projects/:slug/members      # List team members
-POST   /api/v1/projects/:slug/members      # Add member
-PATCH  /api/v1/projects/:slug/members/:id  # Update role
+GET    /api/v1/projects/:id/members      # List team members
+POST   /api/v1/projects/:id/members      # Add member
+PATCH  /api/v1/projects/:id/members/:id  # Update role
 
 # Platform Configuration
-GET    /api/v1/projects/:slug/platforms         # List configured bots
-POST   /api/v1/projects/:slug/platforms         # Add bot integration
-PATCH  /api/v1/projects/:slug/platforms/:id     # Update bot tokens
+GET    /api/v1/projects/:id/platforms         # List configured bots
+POST   /api/v1/projects/:id/platforms         # Add bot integration
+PATCH  /api/v1/projects/:id/platforms/:id     # Update bot tokens
 
 # Identity Management (Cross-Platform Users)
-GET    /api/v1/projects/:slug/identities              # List identities
-POST   /api/v1/projects/:slug/identities              # Create identity
-GET    /api/v1/projects/:slug/identities/:id          # Get identity details
-PATCH  /api/v1/projects/:slug/identities/:id          # Update identity
-POST   /api/v1/projects/:slug/identities/:id/aliases  # Link platform account
-GET    /api/v1/projects/:slug/identities/lookup       # Lookup by platform user
-GET    /api/v1/projects/:slug/identities/:id/messages # Get all messages for identity
+GET    /api/v1/projects/:id/identities              # List identities
+POST   /api/v1/projects/:id/identities              # Create identity
+GET    /api/v1/projects/:id/identities/:id          # Get identity details
+PATCH  /api/v1/projects/:id/identities/:id          # Update identity
+POST   /api/v1/projects/:id/identities/:id/aliases  # Link platform account
+GET    /api/v1/projects/:id/identities/lookup       # Lookup by platform user
+GET    /api/v1/projects/:id/identities/:id/messages # Get all messages for identity
 
 # Conversation History (Ready for Agents)
-GET    /api/v1/projects/:slug/messages          # Query received messages (with identity)
-GET    /api/v1/projects/:slug/messages/sent     # Query sent messages (with identity)
+GET    /api/v1/projects/:id/messages          # Query received messages (with identity)
+GET    /api/v1/projects/:id/messages/sent     # Query sent messages (with identity)
 
 # Webhook Notifications (Event Subscriptions)
-POST   /api/v1/projects/:slug/webhooks          # Subscribe to events
-GET    /api/v1/projects/:slug/webhooks          # List webhooks
-GET    /api/v1/projects/:slug/webhooks/:id/deliveries  # Delivery history
+POST   /api/v1/projects/:id/webhooks          # Subscribe to events
+GET    /api/v1/projects/:id/webhooks          # List webhooks
+GET    /api/v1/projects/:id/webhooks/:id/deliveries  # Delivery history
 
 # Platform Activity Monitoring
-GET    /api/v1/projects/:slug/platforms/logs         # All platform activity
-GET    /api/v1/projects/:slug/platforms/logs/stats   # Activity dashboard
+GET    /api/v1/projects/:id/platforms/logs         # All platform activity
+GET    /api/v1/projects/:id/platforms/logs/stats   # Activity dashboard
 ```
 
 ### **🎮 Platform Capabilities Matrix**

--- a/SEMANTIC_PLAYBOOK.md
+++ b/SEMANTIC_PLAYBOOK.md
@@ -438,11 +438,11 @@ All controller methods accessing project-scoped resources **MUST** use `@AuthCon
 @Post()
 @RequireScopes('platforms:write')
 async create(
-  @Param('projectSlug') projectSlug: string,
+  @Param('projectId') projectId: string,
   @Body() createPlatformDto: CreatePlatformDto,
   @AuthContextParam() authContext: AuthContext,  // REQUIRED
 ) {
-  return this.platformsService.create(projectSlug, createPlatformDto, authContext);
+  return this.platformsService.create(projectId, createPlatformDto, authContext);
 }
 ```
 
@@ -452,14 +452,14 @@ All service methods performing project access **MUST** require `AuthContext`:
 
 ```typescript
 async create(
-  projectSlug: string,
+  projectId: string,
   dto: CreatePlatformDto,
   authContext: AuthContext,  // REQUIRED: Not optional
 ): Promise<PlatformResponse> {
   // First line: Validate project access
   const project = await SecurityUtil.getProjectWithAccess(
     this.prisma,
-    projectSlug,
+    projectId,
     authContext,
     'platform creation',
   );

--- a/WHATSAPP_EVO.md
+++ b/WHATSAPP_EVO.md
@@ -7,6 +7,7 @@ The WhatsApp-Evo provider integrates GateKit with WhatsApp through the Evolution
 ## Features
 
 ### ✅ **Core Capabilities**
+
 - **QR Code Authentication** - Secure WhatsApp connection setup
 - **Real-time Messaging** - Bi-directional message processing
 - **Webhook Integration** - Evolution API webhook handling
@@ -15,6 +16,7 @@ The WhatsApp-Evo provider integrates GateKit with WhatsApp through the Evolution
 - **Message Persistence** - Complete message storage with raw data
 
 ### ✅ **Enterprise Features**
+
 - **Project Isolation** - Each project gets dedicated Evolution API webhook
 - **UUID Security** - Webhook endpoints secured with UUID tokens
 - **Error Recovery** - Graceful handling of Evolution API failures
@@ -24,6 +26,7 @@ The WhatsApp-Evo provider integrates GateKit with WhatsApp through the Evolution
 ## Architecture
 
 ### **Provider Structure**
+
 ```typescript
 @PlatformProviderDecorator('whatsapp-evo')
 export class WhatsAppProvider implements PlatformProvider, PlatformAdapter {
@@ -34,12 +37,14 @@ export class WhatsAppProvider implements PlatformProvider, PlatformAdapter {
 ```
 
 ### **Connection Management**
+
 - **Connection Key**: `${projectId}:${platformId}` for isolation
 - **Instance Strategy**: Uses existing "gatekit" Evolution API instance
 - **Webhook Setup**: Automatic registration with Evolution API
 - **State Tracking**: Connection state and QR code management
 
 ### **Message Flow**
+
 ```
 WhatsApp → Evolution API → Webhook → GateKit → Database → Event Bus
 ```
@@ -51,10 +56,12 @@ WhatsApp → Evolution API → Webhook → GateKit → Database → Event Bus
 Since our QR code API flow is still being refined, you can manually set up WhatsApp connections using Evolution Manager:
 
 #### **Step 1: Access Evolution Manager**
+
 1. Open Evolution Manager in your browser: `http://your-evolution-api-domain/manager`
 2. Login with your Evolution API credentials
 
 #### **Step 2: Create/Manage Instance**
+
 1. **Find existing instance** named "gatekit" (if available)
 2. **OR create new instance**:
    - Instance Name: `gatekit` (or custom name)
@@ -62,6 +69,7 @@ Since our QR code API flow is still being refined, you can manually set up Whats
    - Enable webhook with your GateKit URL
 
 #### **Step 3: QR Code Authentication**
+
 1. In Evolution Manager, navigate to your instance
 2. Click "Connect" or "Generate QR Code"
 3. **Scan QR code with your WhatsApp mobile app**:
@@ -71,20 +79,25 @@ Since our QR code API flow is still being refined, you can manually set up Whats
 4. Wait for connection status to show "Connected" or "Open"
 
 #### **Step 4: Configure Webhook**
+
 In Evolution Manager, set webhook URL to:
+
 ```
 https://your-ngrok-url.ngrok-free.app/api/v1/webhooks/whatsapp-evo/YOUR-WEBHOOK-TOKEN
 ```
 
 **Get your webhook token from GateKit platform configuration:**
+
 ```bash
 curl -X GET "/api/v1/projects/your-project/platforms" \
   -H "X-API-Key: your-api-key" | jq '.[] | select(.platform == "whatsapp-evo") | .webhookUrl'
 ```
 
 #### **Step 5: Test Connection**
+
 1. Send a test message to your WhatsApp number
 2. Check GateKit received messages:
+
 ```bash
 curl -X GET "/api/v1/projects/your-project/messages?platform=whatsapp-evo" \
   -H "X-API-Key: your-api-key"
@@ -117,6 +130,7 @@ curl -X GET "/api/v1/projects/project/platforms/{platform-id}/qr-code" \
 ## Configuration
 
 ### **Required Credentials**
+
 ```json
 {
   "evolutionApiUrl": "https://evo.example.com",
@@ -125,11 +139,13 @@ curl -X GET "/api/v1/projects/project/platforms/{platform-id}/qr-code" \
 ```
 
 ### **Optional Fields**
+
 - `instanceName` - Custom Evolution API instance name
 - `webhookEvents` - Specific events to subscribe to
 - `qrCodeTimeout` - QR code expiration timeout (30-300 seconds)
 
 ### **Example Setup**
+
 ```bash
 # Create WhatsApp-Evo platform
 curl -X POST "/api/v1/projects/my-project/platforms" \
@@ -167,12 +183,14 @@ curl -X POST "/api/v1/projects/my-project/messages/send" \
 ## Implementation Details
 
 ### **Evolution API Integration**
+
 - **Webhook Endpoint**: `/webhook/set/{instanceName}` for configuration
 - **Message Endpoint**: `/message/sendText/{instanceName}` for sending
 - **Payload Format**: Handles both nested and flat message structures
 - **Authentication**: Uses `apikey` header for Evolution API requests
 
 ### **Message Processing**
+
 ```typescript
 // Supports multiple Evolution API payload formats:
 1. body.data.messages[]     // Standard format
@@ -183,6 +201,7 @@ curl -X POST "/api/v1/projects/my-project/messages/send" \
 ```
 
 ### **Error Handling**
+
 - **Network Failures**: Graceful degradation with retry mechanisms
 - **Invalid Payloads**: Safe parsing with fallback values
 - **Connection Issues**: Auto-reconnection and state management
@@ -191,10 +210,12 @@ curl -X POST "/api/v1/projects/my-project/messages/send" \
 ## Testing
 
 ### **Test Suites**
+
 - **Provider Tests** (28 tests): Connection management, webhook processing, message flow
 - **Validator Tests** (29 tests): Credential validation, edge cases, security
 
 ### **Edge Cases Covered**
+
 - Evolution API connectivity issues
 - Malformed webhook payloads
 - Database constraint violations
@@ -203,6 +224,7 @@ curl -X POST "/api/v1/projects/my-project/messages/send" \
 - QR code flow variations
 
 ### **Running Tests**
+
 ```bash
 # Run all WhatsApp-Evo tests
 npm test -- --testPathPatterns="whatsapp.*spec.ts"
@@ -217,6 +239,7 @@ npm test -- --testNamePattern="WhatsAppCredentialsValidator"
 ### **QR Code Flow Issues**
 
 1. **"QR code not available yet" Error**
+
    ```bash
    # Check if Evolution API instance exists
    curl -X GET "https://your-evolution-api-domain/instance/fetchInstances" \
@@ -260,7 +283,7 @@ npm test -- --testNamePattern="WhatsAppCredentialsValidator"
 
 2. **Messages Not Stored in GateKit**
    - Check if webhook calls are reaching GateKit (check server logs)
-   - Verify platform is active: `GET /api/v1/projects/:slug/platforms`
+   - Verify platform is active: `GET /api/v1/projects/:id/platforms`
    - Ensure messages aren't being filtered (fromMe: true)
 
 3. **Evolution Manager Connection States**
@@ -303,7 +326,7 @@ npm test -- --testNamePattern="WhatsAppCredentialsValidator"
 1. **Webhook Not Receiving Messages**
    - Verify Evolution API can reach your webhook URL
    - Check webhook registration: `GET /api/v1/platforms/webhook-routes`
-   - Ensure platform is active: `GET /api/v1/projects/:slug/platforms`
+   - Ensure platform is active: `GET /api/v1/projects/:id/platforms`
 
 2. **QR Code Not Available**
    - Use Evolution Manager for manual QR code generation
@@ -316,6 +339,7 @@ npm test -- --testNamePattern="WhatsAppCredentialsValidator"
    - Validate phone number format (include @s.whatsapp.net for JID)
 
 ### **Debug Commands**
+
 ```bash
 # Check platform health
 curl -X GET "/api/v1/platforms/health" -H "X-API-Key: key"
@@ -330,11 +354,13 @@ curl -X GET "/api/v1/projects/project/messages/stats" -H "X-API-Key: key"
 ## Evolution API Compatibility
 
 ### **Supported Versions**
+
 - Evolution API v2.x
 - Baileys-based WhatsApp Web integration
 - Compatible with standard Evolution API deployments
 
 ### **Webhook Events**
+
 - `QRCODE_UPDATED` - QR code for authentication
 - `CONNECTION_UPDATE` - Connection state changes
 - `MESSAGES_UPSERT` - Incoming messages
@@ -343,13 +369,16 @@ curl -X GET "/api/v1/projects/project/messages/stats" -H "X-API-Key: key"
 ## Future Roadmap
 
 ### **Planned Enhancements**
+
 - **Media Message Support** - Images, documents, audio files
 - **Group Message Handling** - Group chat integration
 - **Message Reactions** - Emoji reactions and interactions
 - **Typing Indicators** - Real-time typing status
 
 ### **Integration Strategy**
+
 The `whatsapp-evo` provider is designed to coexist with future WhatsApp integrations:
+
 - `whatsapp` - Reserved for official WhatsApp Business API
 - `whatsapp-evo` - Evolution API integration (current)
 - `whatsapp-web` - Direct WhatsApp Web integration (future)
@@ -359,6 +388,7 @@ This allows developers to choose the most appropriate WhatsApp integration metho
 ## Support
 
 For questions and support:
+
 - **Discord Community**: https://discord.gg/bQPsvycW
 - **Documentation**: Check `/docs` endpoints for API reference
 - **Test Examples**: See `whatsapp.provider.spec.ts` for usage patterns

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,6 +7,7 @@ GateKit is a universal messaging gateway built with NestJS that provides a unifi
 ## Core Components
 
 ### 1. API Layer
+
 - **NestJS Controllers**: Handle HTTP requests
 - **Guards**: Authentication (JWT/API Key) and authorization (scope-based)
 - **DTOs**: Input validation and transformation
@@ -15,6 +16,7 @@ GateKit is a universal messaging gateway built with NestJS that provides a unifi
 ### 2. Message Queue System
 
 #### Overview
+
 All message sending is handled asynchronously through a Redis-backed Bull queue system.
 
 ```
@@ -24,18 +26,21 @@ Client Request → API → Queue → Processor → Platform Adapter → Platform
 #### Components
 
 **MessageQueue Service** (`src/queues/message.queue.ts`)
+
 - Manages job lifecycle
 - Provides job status tracking
 - Handles retries and failures
 - Exposes queue metrics
 
 **MessageProcessor** (`src/queues/processors/message.processor.ts`)
+
 - Processes queued messages asynchronously
 - Manages platform adapter instances
 - Handles adapter lifecycle (initialization, cleanup)
 - Reports job progress
 
 #### Flow
+
 1. Client sends message request to API
 2. API validates request and platform configuration
 3. Message is queued in Bull/Redis with job ID
@@ -51,12 +56,14 @@ Client Request → API → Queue → Processor → Platform Adapter → Platform
 Each platform (Discord, Telegram, etc.) has its own adapter that implements the `PlatformAdapter` interface.
 
 **Key Features:**
+
 - **Isolation**: Each project gets its own adapter instance
 - **Credential Management**: Encrypted storage in database
 - **Event Handling**: Bidirectional communication via EventBus
 - **Lifecycle Management**: Proper initialization and cleanup
 
 **Factory Pattern:**
+
 ```typescript
 AdapterFactory.createAdapter(platform) → new DiscordAdapter()
 ```
@@ -64,16 +71,19 @@ AdapterFactory.createAdapter(platform) → new DiscordAdapter()
 ### 4. Security Layer
 
 #### Encryption
+
 - **Algorithm**: AES-256-GCM
 - **Key Management**: Environment variable (32+ characters)
 - **Usage**: Platform credentials encryption
 
 #### Authentication
+
 - **Dual Support**: JWT (Auth0) and API Keys
 - **API Key Storage**: SHA-256 hashed in database
 - **Scope System**: Granular permissions per key
 
 #### Webhooks
+
 - **UUID Tokens**: Each platform config gets unique webhook token
 - **No ID Exposure**: Project IDs never exposed in URLs
 - **Validation**: Platform-specific signature verification
@@ -81,6 +91,7 @@ AdapterFactory.createAdapter(platform) → new DiscordAdapter()
 ### 5. Database Schema
 
 Key models:
+
 - **Project**: Core organizational unit
 - **ProjectPlatform**: Platform configurations with encrypted credentials
 - **ApiKey**: Hashed keys with scopes
@@ -90,8 +101,9 @@ Key models:
 ## Data Flow Examples
 
 ### Sending a Message
+
 ```
-1. POST /api/v1/projects/:slug/messages/send
+1. POST /api/v1/projects/:id/messages/send
 2. Validate API key and scopes
 3. Validate project and platform config
 4. Queue message in Bull
@@ -103,6 +115,7 @@ Key models:
 ```
 
 ### Webhook Processing
+
 ```
 1. POST /webhooks/discord/:webhookToken
 2. Look up platform config by UUID token
@@ -116,16 +129,19 @@ Key models:
 ## Scalability Considerations
 
 ### Horizontal Scaling
+
 - **Stateless API**: Can run multiple instances
 - **Queue Workers**: Can scale processor instances
 - **Redis Cluster**: Supports queue distribution
 
 ### Performance Optimizations
+
 - **Adapter Reuse**: Adapters cached per project/platform
 - **Connection Pooling**: Database and Redis connections
 - **Queue Configuration**: Configurable concurrency and rate limits
 
 ### Reliability Features
+
 - **Automatic Retries**: Exponential backoff for failures
 - **Job Persistence**: Redis persistence for queue durability
 - **Graceful Shutdown**: Proper cleanup on termination
@@ -134,12 +150,14 @@ Key models:
 ## Monitoring & Observability
 
 ### Metrics Available
+
 - Queue depth (waiting/active/completed/failed)
 - Message delivery success rate
 - Platform-specific metrics
 - API usage per project/key
 
 ### Logging
+
 - Structured logging with NestJS Logger
 - Job processing logs with job IDs
 - Error tracking with stack traces
@@ -147,6 +165,7 @@ Key models:
 ## Future Enhancements
 
 ### Planned Features
+
 - WebSocket support for real-time messaging
 - Message batching for bulk sends
 - Platform-specific rate limiting
@@ -154,6 +173,7 @@ Key models:
 - Dead letter queue handling
 
 ### Platform Expansion
+
 - Slack integration
 - WhatsApp Business API
 - Email gateway
@@ -163,6 +183,7 @@ Key models:
 ## Development Guidelines
 
 ### Adding New Platforms
+
 1. Create adapter in `src/platforms/adapters/[platform]/`
 2. Implement `PlatformAdapter` interface
 3. Add to `AdapterFactory`
@@ -171,6 +192,7 @@ Key models:
 6. Update documentation
 
 ### Testing Strategy
+
 - Unit tests for business logic
 - Integration tests for API endpoints
 - Mock adapters for testing
@@ -190,24 +212,29 @@ Key models:
 ## Dependencies
 
 ### Core
+
 - NestJS 10.x
 - TypeScript 5.x
 - Node.js 18+
 
 ### Data
+
 - PostgreSQL 16
 - Redis 7
 - Prisma ORM
 
 ### Queue
+
 - Bull (Redis-based queue)
 - bull-board (monitoring UI - optional)
 
 ### Security
+
 - bcrypt (API key hashing)
 - crypto (built-in encryption)
 
 ### Platform SDKs
+
 - discord.js
 - node-telegram-bot-api
 - (others as needed)

--- a/prisma/migrations/20251002015312_use_slug_as_primary_key/migration.sql
+++ b/prisma/migrations/20251002015312_use_slug_as_primary_key/migration.sql
@@ -1,0 +1,56 @@
+-- Step 1: Add a temporary column to store the old UUID id
+ALTER TABLE "projects" ADD COLUMN "old_id" TEXT;
+UPDATE "projects" SET "old_id" = "id";
+
+-- Step 2: Rename slug to new_id temporarily
+ALTER TABLE "projects" ADD COLUMN "new_id" TEXT;
+UPDATE "projects" SET "new_id" = "slug";
+
+-- Step 3: Drop foreign key constraints
+ALTER TABLE "api_keys" DROP CONSTRAINT "api_keys_project_id_fkey";
+ALTER TABLE "project_platforms" DROP CONSTRAINT "project_platforms_project_id_fkey";
+ALTER TABLE "received_messages" DROP CONSTRAINT "received_messages_project_id_fkey";
+ALTER TABLE "sent_messages" DROP CONSTRAINT "sent_messages_project_id_fkey";
+ALTER TABLE "platform_logs" DROP CONSTRAINT "platform_logs_project_id_fkey";
+ALTER TABLE "webhooks" DROP CONSTRAINT "webhooks_project_id_fkey";
+ALTER TABLE "received_reactions" DROP CONSTRAINT "received_reactions_project_id_fkey";
+ALTER TABLE "project_members" DROP CONSTRAINT "project_members_project_id_fkey";
+ALTER TABLE "identities" DROP CONSTRAINT "identities_project_id_fkey";
+ALTER TABLE "identity_aliases" DROP CONSTRAINT "identity_aliases_project_id_fkey";
+
+-- Step 4: Update all foreign keys to use the slug value
+UPDATE "api_keys" ak SET "project_id" = p."new_id" FROM "projects" p WHERE ak."project_id" = p."old_id";
+UPDATE "project_platforms" pp SET "project_id" = p."new_id" FROM "projects" p WHERE pp."project_id" = p."old_id";
+UPDATE "received_messages" rm SET "project_id" = p."new_id" FROM "projects" p WHERE rm."project_id" = p."old_id";
+UPDATE "sent_messages" sm SET "project_id" = p."new_id" FROM "projects" p WHERE sm."project_id" = p."old_id";
+UPDATE "platform_logs" pl SET "project_id" = p."new_id" FROM "projects" p WHERE pl."project_id" = p."old_id";
+UPDATE "webhooks" w SET "project_id" = p."new_id" FROM "projects" p WHERE w."project_id" = p."old_id";
+UPDATE "received_reactions" rr SET "project_id" = p."new_id" FROM "projects" p WHERE rr."project_id" = p."old_id";
+UPDATE "project_members" pm SET "project_id" = p."new_id" FROM "projects" p WHERE pm."project_id" = p."old_id";
+UPDATE "identities" i SET "project_id" = p."new_id" FROM "projects" p WHERE i."project_id" = p."old_id";
+UPDATE "identity_aliases" ia SET "project_id" = p."new_id" FROM "projects" p WHERE ia."project_id" = p."old_id";
+
+-- Step 5: Drop primary key and old id column
+ALTER TABLE "projects" DROP CONSTRAINT "projects_pkey";
+ALTER TABLE "projects" DROP COLUMN "id";
+ALTER TABLE "projects" DROP COLUMN "slug";
+ALTER TABLE "projects" DROP COLUMN "old_id";
+
+-- Step 6: Rename new_id to id and make it primary key
+ALTER TABLE "projects" RENAME COLUMN "new_id" TO "id";
+ALTER TABLE "projects" ADD PRIMARY KEY ("id");
+
+-- Step 7: Recreate foreign key constraints
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "project_platforms" ADD CONSTRAINT "project_platforms_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "received_messages" ADD CONSTRAINT "received_messages_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "sent_messages" ADD CONSTRAINT "sent_messages_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "platform_logs" ADD CONSTRAINT "platform_logs_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "webhooks" ADD CONSTRAINT "webhooks_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "received_reactions" ADD CONSTRAINT "received_reactions_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "project_members" ADD CONSTRAINT "project_members_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "identities" ADD CONSTRAINT "identities_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "identity_aliases" ADD CONSTRAINT "identity_aliases_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Step 8: Add index that was previously on display_name (from another pending migration)
+CREATE INDEX "identities_project_id_display_name_idx" ON "identities"("project_id", "display_name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,10 +49,9 @@ model User {
 }
 
 model Project {
-  id          String              @id @default(uuid())
+  id          String              @id  // Slug is now the primary key
   name        String
   description String?
-  slug        String              @unique
   environment ProjectEnvironment  @default(development)
   isDefault   Boolean             @default(false) @map("is_default")
   settings    Json?

--- a/src/api-keys/api-keys.controller.ts
+++ b/src/api-keys/api-keys.controller.ts
@@ -19,7 +19,7 @@ import type { AuthContext } from '../common/utils/security.util';
 import { Throttle } from '@nestjs/throttler';
 import { ApiScope } from '../common/enums/api-scopes.enum';
 
-@Controller('api/v1/projects/:projectSlug/keys')
+@Controller('api/v1/projects/:project/keys')
 @UseGuards(AppAuthGuard, ProjectAccessGuard)
 export class ApiKeysController {
   constructor(private readonly apiKeysService: ApiKeysService) {}
@@ -52,15 +52,11 @@ export class ApiKeysController {
     ],
   })
   create(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Body() createApiKeyDto: CreateApiKeyDto,
     @AuthContextParam() authContext: AuthContext,
   ) {
-    return this.apiKeysService.create(
-      projectSlug,
-      createApiKeyDto,
-      authContext,
-    );
+    return this.apiKeysService.create(project, createApiKeyDto, authContext);
   }
 
   @Get()
@@ -79,10 +75,10 @@ export class ApiKeysController {
     ],
   })
   findAll(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @AuthContextParam() authContext: AuthContext,
   ) {
-    return this.apiKeysService.findAll(projectSlug, authContext);
+    return this.apiKeysService.findAll(project, authContext);
   }
 
   @Delete(':keyId')
@@ -108,11 +104,11 @@ export class ApiKeysController {
     ],
   })
   revoke(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('keyId') keyId: string,
     @AuthContextParam() authContext: AuthContext,
   ) {
-    return this.apiKeysService.revoke(projectSlug, keyId, authContext);
+    return this.apiKeysService.revoke(project, keyId, authContext);
   }
 
   @Post(':keyId/roll')
@@ -140,10 +136,10 @@ export class ApiKeysController {
     ],
   })
   roll(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('keyId') keyId: string,
     @AuthContextParam() authContext: AuthContext,
   ) {
-    return this.apiKeysService.roll(projectSlug, keyId, authContext);
+    return this.apiKeysService.roll(project, keyId, authContext);
   }
 }

--- a/src/api-keys/api-keys.service.spec.ts
+++ b/src/api-keys/api-keys.service.spec.ts
@@ -19,7 +19,7 @@ describe('ApiKeysService', () => {
 
   const mockAuthContext = {
     authType: 'api-key' as const,
-    project: { id: 'project-id', slug: 'test-project' },
+    project: { id: 'project-id' },
   };
 
   const mockPrismaService = {
@@ -55,7 +55,7 @@ describe('ApiKeysService', () => {
 
   describe('create', () => {
     it('should create API key with specified scopes', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const createDto = {
         name: 'Test Key',
         scopes: ['messages:send', 'messages:read'],
@@ -63,7 +63,7 @@ describe('ApiKeysService', () => {
 
       const mockProject = {
         id: 'project-id',
-        slug: projectSlug,
+
         environment: 'development',
       };
       const mockApiKey = 'gk_test_abc123';
@@ -88,7 +88,7 @@ describe('ApiKeysService', () => {
       });
 
       const result = await service.create(
-        projectSlug,
+        projectId,
         createDto,
         mockAuthContext,
       );
@@ -163,10 +163,10 @@ describe('ApiKeysService', () => {
 
   describe('findAll', () => {
     it('should return masked API keys for a project', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const mockProject = {
         id: 'project-id',
-        slug: projectSlug,
+
         environment: 'development',
       };
 
@@ -185,7 +185,7 @@ describe('ApiKeysService', () => {
         },
       ]);
 
-      const result = await service.findAll(projectSlug, mockAuthContext);
+      const result = await service.findAll(projectId, mockAuthContext);
 
       expect(result).toHaveLength(1);
       expect(result[0]).toHaveProperty('maskedKey');
@@ -203,7 +203,7 @@ describe('ApiKeysService', () => {
 
   describe('revoke', () => {
     it('should revoke an active API key', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const keyId = 'key-id';
 
       mockPrismaService.project.findUnique.mockResolvedValue({
@@ -216,7 +216,7 @@ describe('ApiKeysService', () => {
       });
       mockPrismaService.apiKey.update.mockResolvedValue({});
 
-      const result = await service.revoke(projectSlug, keyId, mockAuthContext);
+      const result = await service.revoke(projectId, keyId, mockAuthContext);
 
       expect(mockPrismaService.apiKey.update).toHaveBeenCalledWith({
         where: { id: keyId },

--- a/src/api-keys/api-keys.service.ts
+++ b/src/api-keys/api-keys.service.ts
@@ -9,7 +9,7 @@ export class ApiKeysService {
   constructor(private prisma: PrismaService) {}
 
   async create(
-    projectSlug: string,
+    projectId: string,
     createApiKeyDto: CreateApiKeyDto,
     authContext: AuthContext,
     createdBy?: string,
@@ -17,7 +17,7 @@ export class ApiKeysService {
     // Get project and validate access in one step
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'API key creation',
     );
@@ -64,11 +64,11 @@ export class ApiKeysService {
     };
   }
 
-  async findAll(projectSlug: string, authContext: AuthContext) {
+  async findAll(projectId: string, authContext: AuthContext) {
     // Get project and validate access in one step
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'API key listing',
     );
@@ -94,11 +94,11 @@ export class ApiKeysService {
     }));
   }
 
-  async revoke(projectSlug: string, keyId: string, authContext: AuthContext) {
+  async revoke(projectId: string, keyId: string, authContext: AuthContext) {
     // Get project and validate access in one step
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'API key revocation',
     );
@@ -127,7 +127,7 @@ export class ApiKeysService {
   }
 
   async roll(
-    projectSlug: string,
+    projectId: string,
     keyId: string,
     authContext: AuthContext,
     createdBy?: string,
@@ -135,7 +135,7 @@ export class ApiKeysService {
     // Get project and validate access in one step
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'API key rolling',
     );

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -29,7 +29,6 @@ describe('AuthController', () => {
           },
           project: {
             id: 'project-456',
-            slug: 'test-project',
             name: 'Test Project',
           },
         };
@@ -42,7 +41,6 @@ describe('AuthController', () => {
           permissions: ['projects:read', 'projects:write', 'messages:send'],
           project: {
             id: 'project-456',
-            slug: 'test-project',
             name: 'Test Project',
           },
           apiKey: {
@@ -62,7 +60,6 @@ describe('AuthController', () => {
           },
           project: {
             id: 'project-456',
-            slug: 'test-project',
             name: 'Test Project',
           },
         };
@@ -84,7 +81,6 @@ describe('AuthController', () => {
           },
           project: {
             id: 'project-456',
-            slug: 'test-project',
             name: 'Test Project',
           },
         };
@@ -101,7 +97,6 @@ describe('AuthController', () => {
           authType: 'api-key',
           project: {
             id: 'project-456',
-            slug: 'test-project',
             name: 'Test Project',
           },
         };

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -12,7 +12,6 @@ interface ApiKeyRequest {
   };
   project: {
     id: string;
-    slug: string;
     name: string;
   };
 }
@@ -65,7 +64,6 @@ export class AuthController {
       response.permissions = apiKey.scopes || [];
       response.project = {
         id: project.id,
-        slug: project.slug,
         name: project.name,
       };
       response.apiKey = {

--- a/src/auth/dto/permission-response.dto.ts
+++ b/src/auth/dto/permission-response.dto.ts
@@ -3,7 +3,6 @@ export class PermissionResponse {
   permissions: string[];
   project?: {
     id: string;
-    slug: string;
     name: string;
   };
   user?: {

--- a/src/common/utils/security.util.spec.ts
+++ b/src/common/utils/security.util.spec.ts
@@ -36,7 +36,7 @@ describe('SecurityUtil', () => {
 
       expect(result).toEqual(mockProject);
       expect(mockPrisma.project.findUnique).toHaveBeenCalledWith({
-        where: { slug: 'test-project' },
+        where: { id: 'test-project' },
       });
     });
 
@@ -56,9 +56,7 @@ describe('SecurityUtil', () => {
           'test operation',
         ),
       ).rejects.toThrow(
-        new NotFoundException(
-          "Project with slug 'nonexistent-project' not found",
-        ),
+        new NotFoundException("Project 'nonexistent-project' not found"),
       );
     });
 

--- a/src/common/utils/security.util.ts
+++ b/src/common/utils/security.util.ts
@@ -3,13 +3,12 @@ import { ProjectEnvironment } from '@prisma/client';
 
 export interface AuthContext {
   authType: 'api-key' | 'jwt';
-  project?: { id: string; slug: string };
+  project?: { id: string };
   user?: { userId: string; email?: string };
 }
 
 export interface ProjectWithAccess {
   id: string;
-  slug: string;
   name: string;
   environment: ProjectEnvironment;
   ownerId: string;
@@ -24,18 +23,16 @@ export class SecurityUtil {
    */
   static async getProjectWithAccess(
     prisma: any,
-    projectSlug: string,
+    projectId: string,
     authContext: AuthContext,
     operation: string,
   ): Promise<ProjectWithAccess> {
     const project = await prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
     });
 
     if (!project) {
-      throw new NotFoundException(
-        `Project with slug '${projectSlug}' not found`,
-      );
+      throw new NotFoundException(`Project '${projectId}' not found`);
     }
 
     SecurityUtil.validateProjectAccess(authContext, project.id, operation);

--- a/src/identities/identities.controller.ts
+++ b/src/identities/identities.controller.ts
@@ -22,7 +22,7 @@ import { SdkContract } from '../common/decorators/sdk-contract.decorator';
 import { RequireScopes } from '../common/decorators/scopes.decorator';
 import { ApiScope } from '../common/enums/api-scopes.enum';
 
-@Controller('api/v1/projects/:projectSlug/identities')
+@Controller('api/v1/projects/:project/identities')
 @UseGuards(AppAuthGuard, ProjectAccessGuard)
 export class IdentitiesController {
   constructor(private readonly identitiesService: IdentitiesService) {}
@@ -64,12 +64,12 @@ export class IdentitiesController {
     ],
   })
   create(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Body() createIdentityDto: CreateIdentityDto,
     @AuthContextParam() authContext: AuthContext,
   ) {
     return this.identitiesService.create(
-      projectSlug,
+      project,
       createIdentityDto,
       authContext,
     );
@@ -91,10 +91,10 @@ export class IdentitiesController {
     ],
   })
   findAll(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @AuthContextParam() authContext: AuthContext,
   ) {
-    return this.identitiesService.findAll(projectSlug, authContext);
+    return this.identitiesService.findAll(project, authContext);
   }
 
   @Get('lookup')
@@ -126,13 +126,13 @@ export class IdentitiesController {
     ],
   })
   lookup(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Query('platformId') platformId: string,
     @Query('providerUserId') providerUserId: string,
     @AuthContextParam() authContext: AuthContext,
   ) {
     return this.identitiesService.lookupByPlatformUser(
-      projectSlug,
+      project,
       platformId,
       providerUserId,
       authContext,
@@ -162,11 +162,11 @@ export class IdentitiesController {
     ],
   })
   findOne(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('id') id: string,
     @AuthContextParam() authContext: AuthContext,
   ) {
-    return this.identitiesService.findOne(projectSlug, id, authContext);
+    return this.identitiesService.findOne(project, id, authContext);
   }
 
   @Patch(':id')
@@ -211,13 +211,13 @@ export class IdentitiesController {
     ],
   })
   update(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('id') id: string,
     @Body() updateIdentityDto: UpdateIdentityDto,
     @AuthContextParam() authContext: AuthContext,
   ) {
     return this.identitiesService.update(
-      projectSlug,
+      project,
       id,
       updateIdentityDto,
       authContext,
@@ -263,13 +263,13 @@ export class IdentitiesController {
     ],
   })
   addAlias(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('id') id: string,
     @Body() addAliasDto: AddAliasDto,
     @AuthContextParam() authContext: AuthContext,
   ) {
     return this.identitiesService.addAlias(
-      projectSlug,
+      project,
       id,
       addAliasDto,
       authContext,
@@ -304,13 +304,13 @@ export class IdentitiesController {
     ],
   })
   removeAlias(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('id') id: string,
     @Param('aliasId') aliasId: string,
     @AuthContextParam() authContext: AuthContext,
   ) {
     return this.identitiesService.removeAlias(
-      projectSlug,
+      project,
       id,
       aliasId,
       authContext,
@@ -340,11 +340,11 @@ export class IdentitiesController {
     ],
   })
   remove(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('id') id: string,
     @AuthContextParam() authContext: AuthContext,
   ) {
-    return this.identitiesService.remove(projectSlug, id, authContext);
+    return this.identitiesService.remove(project, id, authContext);
   }
 
   @Get(':id/messages')
@@ -371,12 +371,12 @@ export class IdentitiesController {
     ],
   })
   getMessages(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('id') id: string,
     @AuthContextParam() authContext: AuthContext,
   ) {
     return this.identitiesService.getMessagesForIdentity(
-      projectSlug,
+      project,
       id,
       authContext,
     );
@@ -406,12 +406,12 @@ export class IdentitiesController {
     ],
   })
   getReactions(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('id') id: string,
     @AuthContextParam() authContext: AuthContext,
   ) {
     return this.identitiesService.getReactionsForIdentity(
-      projectSlug,
+      project,
       id,
       authContext,
     );

--- a/src/identities/identities.service.ts
+++ b/src/identities/identities.service.ts
@@ -22,14 +22,14 @@ export class IdentitiesService {
    * Create a new identity with aliases
    */
   async create(
-    projectSlug: string,
+    projectId: string,
     createDto: CreateIdentityDto,
     authContext: AuthContext,
   ) {
     // SECURITY: Get project and validate access
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'create identities',
     );
@@ -114,7 +114,7 @@ export class IdentitiesService {
     });
 
     this.logger.log(
-      `Created identity ${identity.id} with ${identity.aliases.length} aliases for project ${project.slug}`,
+      `Created identity ${identity.id} with ${identity.aliases.length} aliases for project ${project.id}`,
     );
 
     return identity;
@@ -123,11 +123,11 @@ export class IdentitiesService {
   /**
    * Get all identities for a project
    */
-  async findAll(projectSlug: string, authContext: AuthContext) {
+  async findAll(projectId: string, authContext: AuthContext) {
     // SECURITY: Get project and validate access
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'list identities',
     );
@@ -162,14 +162,14 @@ export class IdentitiesService {
    * Get a single identity by ID
    */
   async findOne(
-    projectSlug: string,
+    projectId: string,
     identityId: string,
     authContext: AuthContext,
   ) {
     // SECURITY: Get project and validate access
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'view identity',
     );
@@ -201,7 +201,7 @@ export class IdentitiesService {
 
     if (!identity) {
       throw new NotFoundException(
-        `Identity ${identityId} not found in project ${projectSlug}`,
+        `Identity ${identityId} not found in project ${projectId}`,
       );
     }
 
@@ -212,7 +212,7 @@ export class IdentitiesService {
    * Look up identity by platform user ID
    */
   async lookupByPlatformUser(
-    projectSlug: string,
+    projectId: string,
     platformId: string,
     providerUserId: string,
     authContext: AuthContext,
@@ -220,7 +220,7 @@ export class IdentitiesService {
     // SECURITY: Get project and validate access
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'lookup identity',
     );
@@ -264,7 +264,7 @@ export class IdentitiesService {
    * Update identity metadata
    */
   async update(
-    projectSlug: string,
+    projectId: string,
     identityId: string,
     updateDto: UpdateIdentityDto,
     authContext: AuthContext,
@@ -272,7 +272,7 @@ export class IdentitiesService {
     // SECURITY: Get project and validate access
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'update identity',
     );
@@ -287,7 +287,7 @@ export class IdentitiesService {
 
     if (!existing) {
       throw new NotFoundException(
-        `Identity ${identityId} not found in project ${projectSlug}`,
+        `Identity ${identityId} not found in project ${projectId}`,
       );
     }
 
@@ -313,9 +313,7 @@ export class IdentitiesService {
       },
     });
 
-    this.logger.log(
-      `Updated identity ${identityId} in project ${project.slug}`,
-    );
+    this.logger.log(`Updated identity ${identityId} in project ${project.id}`);
 
     return updated;
   }
@@ -324,7 +322,7 @@ export class IdentitiesService {
    * Add a new alias to an existing identity
    */
   async addAlias(
-    projectSlug: string,
+    projectId: string,
     identityId: string,
     addAliasDto: AddAliasDto,
     authContext: AuthContext,
@@ -332,7 +330,7 @@ export class IdentitiesService {
     // SECURITY: Get project and validate access
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'add identity alias',
     );
@@ -347,7 +345,7 @@ export class IdentitiesService {
 
     if (!identity) {
       throw new NotFoundException(
-        `Identity ${identityId} not found in project ${projectSlug}`,
+        `Identity ${identityId} not found in project ${projectId}`,
       );
     }
 
@@ -361,7 +359,7 @@ export class IdentitiesService {
 
     if (!platform) {
       throw new BadRequestException(
-        `Platform ${addAliasDto.platformId} does not belong to project ${projectSlug}`,
+        `Platform ${addAliasDto.platformId} does not belong to project ${projectId}`,
       );
     }
 
@@ -404,7 +402,7 @@ export class IdentitiesService {
     });
 
     this.logger.log(
-      `Added alias ${alias.id} to identity ${identityId} in project ${project.slug}`,
+      `Added alias ${alias.id} to identity ${identityId} in project ${project.id}`,
     );
 
     return alias;
@@ -414,7 +412,7 @@ export class IdentitiesService {
    * Remove an alias from an identity
    */
   async removeAlias(
-    projectSlug: string,
+    projectId: string,
     identityId: string,
     aliasId: string,
     authContext: AuthContext,
@@ -422,7 +420,7 @@ export class IdentitiesService {
     // SECURITY: Get project and validate access
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'remove identity alias',
     );
@@ -438,7 +436,7 @@ export class IdentitiesService {
 
     if (!alias) {
       throw new NotFoundException(
-        `Alias ${aliasId} not found for identity ${identityId} in project ${projectSlug}`,
+        `Alias ${aliasId} not found for identity ${identityId} in project ${projectId}`,
       );
     }
 
@@ -458,7 +456,7 @@ export class IdentitiesService {
     });
 
     this.logger.log(
-      `Removed alias ${aliasId} from identity ${identityId} in project ${project.slug}`,
+      `Removed alias ${aliasId} from identity ${identityId} in project ${project.id}`,
     );
 
     return { success: true, message: 'Alias removed successfully' };
@@ -468,14 +466,14 @@ export class IdentitiesService {
    * Delete an identity (cascades to aliases)
    */
   async remove(
-    projectSlug: string,
+    projectId: string,
     identityId: string,
     authContext: AuthContext,
   ) {
     // SECURITY: Get project and validate access
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'delete identity',
     );
@@ -490,7 +488,7 @@ export class IdentitiesService {
 
     if (!identity) {
       throw new NotFoundException(
-        `Identity ${identityId} not found in project ${projectSlug}`,
+        `Identity ${identityId} not found in project ${projectId}`,
       );
     }
 
@@ -499,7 +497,7 @@ export class IdentitiesService {
     });
 
     this.logger.log(
-      `Deleted identity ${identityId} from project ${project.slug}`,
+      `Deleted identity ${identityId} from project ${project.id}`,
     );
 
     return { success: true, message: 'Identity deleted successfully' };
@@ -509,14 +507,14 @@ export class IdentitiesService {
    * Get messages for a specific identity (dynamic resolution via JOIN)
    */
   async getMessagesForIdentity(
-    projectSlug: string,
+    projectId: string,
     identityId: string,
     authContext: AuthContext,
   ) {
     // SECURITY: Get project and validate access
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'view identity messages',
     );
@@ -534,7 +532,7 @@ export class IdentitiesService {
 
     if (!identity) {
       throw new NotFoundException(
-        `Identity ${identityId} not found in project ${projectSlug}`,
+        `Identity ${identityId} not found in project ${projectId}`,
       );
     }
 
@@ -557,14 +555,14 @@ export class IdentitiesService {
    * Get reactions for a specific identity (dynamic resolution via JOIN)
    */
   async getReactionsForIdentity(
-    projectSlug: string,
+    projectId: string,
     identityId: string,
     authContext: AuthContext,
   ) {
     // SECURITY: Get project and validate access
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'view identity reactions',
     );
@@ -582,7 +580,7 @@ export class IdentitiesService {
 
     if (!identity) {
       throw new NotFoundException(
-        `Identity ${identityId} not found in project ${projectSlug}`,
+        `Identity ${identityId} not found in project ${projectId}`,
       );
     }
 

--- a/src/messages/messages.controller.ts
+++ b/src/messages/messages.controller.ts
@@ -21,7 +21,7 @@ import { AuthContextParam } from '../common/decorators/auth-context.decorator';
 import type { AuthContext } from '../common/utils/security.util';
 import { ApiScope } from '../common/enums/api-scopes.enum';
 
-@Controller('api/v1/projects/:projectSlug/messages')
+@Controller('api/v1/projects/:project/messages')
 @UseGuards(AppAuthGuard, ProjectAccessGuard)
 export class MessagesController {
   constructor(
@@ -122,11 +122,11 @@ export class MessagesController {
     ],
   })
   async getMessages(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Query() query: QueryMessagesDto,
     @AuthContextParam() authContext: AuthContext,
   ) {
-    return this.messagesService.getMessages(projectSlug, query, authContext);
+    return this.messagesService.getMessages(project, query, authContext);
   }
 
   @Get('stats')
@@ -144,8 +144,8 @@ export class MessagesController {
       },
     ],
   })
-  async getMessageStats(@Param('projectSlug') projectSlug: string) {
-    return this.messagesService.getMessageStats(projectSlug);
+  async getMessageStats(@Param('project') project: string) {
+    return this.messagesService.getMessageStats(project);
   }
 
   @Get(':messageId')
@@ -171,10 +171,10 @@ export class MessagesController {
     ],
   })
   async getMessage(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('messageId') messageId: string,
   ) {
-    return this.messagesService.getMessage(projectSlug, messageId);
+    return this.messagesService.getMessage(project, messageId);
   }
 
   @Delete('cleanup')
@@ -200,10 +200,10 @@ export class MessagesController {
     ],
   })
   async deleteOldMessages(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Body('daysBefore') daysBefore: number,
   ) {
-    return this.messagesService.deleteOldMessages(projectSlug, daysBefore);
+    return this.messagesService.deleteOldMessages(project, daysBefore);
   }
 
   @Post('send')
@@ -255,13 +255,10 @@ export class MessagesController {
     ],
   })
   async sendMessage(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Body() sendMessageDto: SendMessageDto,
   ) {
-    return this.platformMessagesService.sendMessage(
-      projectSlug,
-      sendMessageDto,
-    );
+    return this.platformMessagesService.sendMessage(project, sendMessageDto);
   }
 
   @Get('status/:jobId')
@@ -283,7 +280,7 @@ export class MessagesController {
     ],
   })
   async getMessageStatus(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('jobId') jobId: string,
   ) {
     return this.platformMessagesService.getMessageStatus(jobId);
@@ -312,7 +309,7 @@ export class MessagesController {
     ],
   })
   async retryMessage(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('jobId') jobId: string,
   ) {
     return this.platformMessagesService.retryMessage(jobId);
@@ -356,15 +353,11 @@ export class MessagesController {
     ],
   })
   async getSentMessages(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Query() query: any,
     @AuthContextParam() authContext: AuthContext,
   ) {
-    return this.messagesService.getSentMessages(
-      projectSlug,
-      query,
-      authContext,
-    );
+    return this.messagesService.getSentMessages(project, query, authContext);
   }
 
   @Post('react')
@@ -407,12 +400,12 @@ export class MessagesController {
     ],
   })
   async reactToMessage(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Body() sendReactionDto: SendReactionDto,
     @AuthContextParam() authContext: AuthContext,
   ) {
     return this.platformMessagesService.reactToMessage(
-      projectSlug,
+      project,
       sendReactionDto,
       authContext,
     );
@@ -453,12 +446,12 @@ export class MessagesController {
     ],
   })
   async unreactToMessage(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Body() sendReactionDto: SendReactionDto,
     @AuthContextParam() authContext: AuthContext,
   ) {
     return this.platformMessagesService.unreactToMessage(
-      projectSlug,
+      project,
       sendReactionDto,
       authContext,
     );

--- a/src/messages/messages.service.ts
+++ b/src/messages/messages.service.ts
@@ -145,14 +145,14 @@ export class MessagesService {
   }
 
   async getMessages(
-    projectSlug: string,
+    projectId: string,
     query: QueryMessagesDto,
     authContext: AuthContext,
   ) {
     // Get project and validate access in one step
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'message retrieval',
     );
@@ -322,9 +322,9 @@ export class MessagesService {
     };
   }
 
-  async getMessage(projectSlug: string, messageId: string) {
+  async getMessage(projectId: string, messageId: string) {
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
     });
 
     if (!project) {
@@ -427,9 +427,9 @@ export class MessagesService {
     };
   }
 
-  async getMessageStats(projectSlug: string) {
+  async getMessageStats(projectId: string) {
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
     });
 
     if (!project) {
@@ -506,9 +506,9 @@ export class MessagesService {
     };
   }
 
-  async deleteOldMessages(projectSlug: string, daysBefore: number) {
+  async deleteOldMessages(projectId: string, daysBefore: number) {
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
     });
 
     if (!project) {
@@ -534,14 +534,14 @@ export class MessagesService {
   }
 
   async getSentMessages(
-    projectSlug: string,
+    projectId: string,
     query: any,
     authContext: AuthContext,
   ) {
     // SECURITY: Get project and validate access
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'sent message retrieval',
     );

--- a/src/platforms/PLATFORM-DEVELOPMENT.md
+++ b/src/platforms/PLATFORM-DEVELOPMENT.md
@@ -12,7 +12,10 @@ Create a new file: `src/platforms/providers/{platform}.provider.ts`
 
 ```typescript
 import { Injectable, Logger, Inject } from '@nestjs/common';
-import { PlatformProvider, WebhookConfig } from '../interfaces/platform-provider.interface';
+import {
+  PlatformProvider,
+  WebhookConfig,
+} from '../interfaces/platform-provider.interface';
 import { PlatformAdapter } from '../interfaces/platform-adapter.interface';
 import { MessageEnvelopeV1 } from '../interfaces/message-envelope.interface';
 import { EVENT_BUS, type IEventBus } from '../interfaces/event-bus.interface';
@@ -31,9 +34,7 @@ export class YourPlatformProvider implements PlatformProvider, PlatformAdapter {
   readonly connectionType = 'webhook' as const; // or 'websocket' | 'polling' | 'http'
   readonly channel = 'your-platform' as const;
 
-  constructor(
-    @Inject(EVENT_BUS) private readonly eventBus: IEventBus,
-  ) {}
+  constructor(@Inject(EVENT_BUS) private readonly eventBus: IEventBus) {}
 
   // Platform Provider methods
   async initialize(): Promise<void> {
@@ -49,7 +50,10 @@ export class YourPlatformProvider implements PlatformProvider, PlatformAdapter {
     await Promise.all(promises);
   }
 
-  async createAdapter(projectId: string, credentials: any): Promise<PlatformAdapter> {
+  async createAdapter(
+    projectId: string,
+    credentials: any,
+  ): Promise<PlatformAdapter> {
     // Create platform-specific connection/client
     // Store connection info
     // Return this as the adapter
@@ -148,15 +152,17 @@ export class PlatformsModule {}
 ### 3. That's It!
 
 Your platform is now:
+
 - ✅ Auto-discovered and registered
 - ✅ Available in `/api/v1/platforms/supported`
-- ✅ Usable for message sending via `/api/v1/projects/:slug/messages/send`
+- ✅ Usable for message sending via `/api/v1/projects/:id/messages/send`
 - ✅ Health monitored via `/api/v1/platforms/health`
 - ✅ Webhook-enabled (if configured) via `/api/v1/webhooks/your-platform/:token`
 
 ## Connection Strategies
 
 ### WebSocket Platforms (like Discord)
+
 ```typescript
 readonly connectionType = 'websocket' as const;
 
@@ -180,6 +186,7 @@ async createAdapter(projectId: string, credentials: any) {
 ```
 
 ### Webhook Platforms (like Telegram)
+
 ```typescript
 readonly connectionType = 'webhook' as const;
 
@@ -198,6 +205,7 @@ getWebhookConfig(): WebhookConfig {
 ```
 
 ### Polling Platforms
+
 ```typescript
 readonly connectionType = 'polling' as const;
 
@@ -218,21 +226,25 @@ async createAdapter(projectId: string, credentials: any) {
 ## Best Practices
 
 ### Thread Safety
+
 - **Never use shared state** across projects
 - **Always pass projectId** to methods that need it
 - **Use connection-specific state** stored in `connections` Map
 
 ### Error Handling
+
 - **Always wrap in try/catch** blocks
 - **Return fallback message IDs** on errors (e.g., 'platform-not-ready')
 - **Log errors with context** (projectId, error details)
 
 ### Resource Management
+
 - **Implement proper cleanup** in `removeAdapter()`
 - **Handle connection limits** if applicable
 - **Clean up on shutdown** in `shutdown()`
 
 ### Testing
+
 - **Test thread safety** - concurrent operations across projects
 - **Test project isolation** - verify no cross-contamination
 - **Test connection management** - reuse, limits, cleanup
@@ -240,12 +252,12 @@ async createAdapter(projectId: string, credentials: any) {
 
 ## Connection Types
 
-| Type | Use Case | Examples | Webhook Support |
-|------|----------|----------|-----------------|
-| `websocket` | Real-time, persistent connections | Discord, Slack RTM | No (uses events) |
-| `webhook` | Event-driven, stateless | Telegram, WhatsApp | Yes (required) |
-| `polling` | Simple, stateless polling | Email, SMS services | No |
-| `http` | Request/response only | REST APIs | No |
+| Type        | Use Case                          | Examples            | Webhook Support  |
+| ----------- | --------------------------------- | ------------------- | ---------------- |
+| `websocket` | Real-time, persistent connections | Discord, Slack RTM  | No (uses events) |
+| `webhook`   | Event-driven, stateless           | Telegram, WhatsApp  | Yes (required)   |
+| `polling`   | Simple, stateless polling         | Email, SMS services | No               |
+| `http`      | Request/response only             | REST APIs           | No               |
 
 ## Platform Capabilities
 
@@ -260,10 +272,12 @@ Each platform provider automatically exposes:
 ## Example: Real Platform Implementation
 
 See existing implementations:
+
 - **Discord**: `src/platforms/providers/discord.provider.ts` (WebSocket)
 - **Telegram**: `src/platforms/providers/telegram.provider.ts` (Webhook)
 
 These serve as complete examples showing:
+
 - Connection management patterns
 - Message envelope creation
 - Error handling strategies
@@ -273,6 +287,7 @@ These serve as complete examples showing:
 ## Migration from Legacy
 
 If migrating from old adapter patterns:
+
 1. Move connection logic from separate connection managers into provider
 2. Move message logic from separate adapters into provider
 3. Implement both `PlatformProvider` and `PlatformAdapter` interfaces
@@ -280,6 +295,7 @@ If migrating from old adapter patterns:
 5. Remove old adapter/factory references from modules
 
 The new architecture eliminates:
+
 - ❌ Separate adapter classes
 - ❌ Connection manager services
 - ❌ Manual factory registration
@@ -287,6 +303,7 @@ The new architecture eliminates:
 - ❌ Shared state between projects
 
 And provides:
+
 - ✅ Single-file platform implementation
 - ✅ Auto-discovery and registration
 - ✅ Complete isolation between platforms

--- a/src/platforms/controllers/platform-logs.controller.ts
+++ b/src/platforms/controllers/platform-logs.controller.ts
@@ -7,7 +7,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { QueryPlatformLogsDto } from '../dto/query-platform-logs.dto';
 import { ApiScope } from '../../common/enums/api-scopes.enum';
 
-@Controller('api/v1/projects/:slug/platforms')
+@Controller('api/v1/projects/:project/platforms')
 @UseGuards(AppAuthGuard)
 export class PlatformLogsController {
   constructor(
@@ -77,20 +77,20 @@ export class PlatformLogsController {
     ],
   })
   async listLogs(
-    @Param('slug') slug: string,
+    @Param('project') project: string,
     @Query() query: QueryPlatformLogsDto,
   ) {
     // Get project to ensure access control
-    const project = await this.prisma.project.findUnique({
-      where: { slug },
+    const projectRecord = await this.prisma.project.findUnique({
+      where: { id: project },
     });
 
-    if (!project) {
-      throw new Error(`Project with slug '${slug}' not found`);
+    if (!projectRecord) {
+      throw new Error(`Project '${project}' not found`);
     }
 
     const options = {
-      projectId: project.id,
+      projectId: projectRecord.id,
       platform: query.platform,
       level: query.level,
       category: query.category,
@@ -157,21 +157,21 @@ export class PlatformLogsController {
     ],
   })
   async getPlatformLogs(
-    @Param('slug') slug: string,
+    @Param('project') project: string,
     @Param('platformId') platformId: string,
     @Query() query: QueryPlatformLogsDto,
   ) {
     // Get project to ensure access control
-    const project = await this.prisma.project.findUnique({
-      where: { slug },
+    const projectRecord = await this.prisma.project.findUnique({
+      where: { id: project },
     });
 
-    if (!project) {
-      throw new Error(`Project with slug '${slug}' not found`);
+    if (!projectRecord) {
+      throw new Error(`Project '${project}' not found`);
     }
 
     const options = {
-      projectId: project.id,
+      projectId: projectRecord.id,
       platformId,
       level: query.level,
       category: query.category,
@@ -199,16 +199,16 @@ export class PlatformLogsController {
       },
     ],
   })
-  async getLogStats(@Param('slug') slug: string) {
+  async getLogStats(@Param('project') project: string) {
     // Get project to ensure access control
-    const project = await this.prisma.project.findUnique({
-      where: { slug },
+    const projectRecord = await this.prisma.project.findUnique({
+      where: { id: project },
     });
 
-    if (!project) {
-      throw new Error(`Project with slug '${slug}' not found`);
+    if (!projectRecord) {
+      throw new Error(`Project '${project}' not found`);
     }
 
-    return this.platformLogsService.getLogStats(project.id);
+    return this.platformLogsService.getLogStats(projectRecord.id);
   }
 }

--- a/src/platforms/messages/messages.service.reactions.spec.ts
+++ b/src/platforms/messages/messages.service.reactions.spec.ts
@@ -68,19 +68,18 @@ describe('MessagesService - Reactions', () => {
   });
 
   describe('reactToMessage', () => {
-    const projectSlug = 'test-project';
+    const projectId = 'test-project';
     const platformId = 'platform-123';
     const messageId = '42';
     const emoji = '👍';
 
     const mockProject = {
       id: 'project-id-123',
-      slug: projectSlug,
     };
 
     const mockAuthContext = {
       authType: 'api-key' as const,
-      project: { id: 'project-id-123', slug: projectSlug },
+      project: { id: 'project-id-123' },
     };
 
     const mockPlatformConfig = {
@@ -120,7 +119,7 @@ describe('MessagesService - Reactions', () => {
       mockPlatformRegistry.getProvider.mockReturnValue(mockProvider);
 
       const result = await service.reactToMessage(
-        projectSlug,
+        projectId,
         {
           platformId,
           messageId,
@@ -158,7 +157,7 @@ describe('MessagesService - Reactions', () => {
       mockPlatformRegistry.getProvider.mockReturnValue(mockProvider);
 
       const result = await service.reactToMessage(
-        projectSlug,
+        projectId,
         {
           platformId,
           messageId,
@@ -190,7 +189,7 @@ describe('MessagesService - Reactions', () => {
 
       await expect(
         service.reactToMessage(
-          projectSlug,
+          projectId,
           {
             platformId,
             messageId,
@@ -202,7 +201,7 @@ describe('MessagesService - Reactions', () => {
 
       await expect(
         service.reactToMessage(
-          projectSlug,
+          projectId,
           {
             platformId,
             messageId,
@@ -233,7 +232,7 @@ describe('MessagesService - Reactions', () => {
 
       await expect(
         service.reactToMessage(
-          projectSlug,
+          projectId,
           {
             platformId,
             messageId,
@@ -245,7 +244,7 @@ describe('MessagesService - Reactions', () => {
 
       await expect(
         service.reactToMessage(
-          projectSlug,
+          projectId,
           {
             platformId,
             messageId,
@@ -260,19 +259,18 @@ describe('MessagesService - Reactions', () => {
   });
 
   describe('unreactToMessage', () => {
-    const projectSlug = 'test-project';
+    const projectId = 'test-project';
     const platformId = 'platform-123';
     const messageId = '42';
     const emoji = '👍';
 
     const mockProject = {
       id: 'project-id-123',
-      slug: projectSlug,
     };
 
     const mockAuthContext = {
       authType: 'api-key' as const,
-      project: { id: 'project-id-123', slug: projectSlug },
+      project: { id: 'project-id-123' },
     };
 
     const mockPlatformConfig = {
@@ -305,7 +303,7 @@ describe('MessagesService - Reactions', () => {
       mockPlatformRegistry.getProvider.mockReturnValue(mockProvider);
 
       const result = await service.unreactToMessage(
-        projectSlug,
+        projectId,
         {
           platformId,
           messageId,
@@ -347,7 +345,7 @@ describe('MessagesService - Reactions', () => {
 
       await expect(
         service.unreactToMessage(
-          projectSlug,
+          projectId,
           {
             platformId,
             messageId,

--- a/src/platforms/messages/messages.service.spec.ts
+++ b/src/platforms/messages/messages.service.spec.ts
@@ -80,7 +80,7 @@ describe('MessagesService', () => {
 
   describe('sendMessage', () => {
     it('should queue message for Discord platform', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const sendMessageDto = {
         targets: [
           {
@@ -94,7 +94,6 @@ describe('MessagesService', () => {
 
       mockPrismaService.project.findUnique.mockResolvedValue({
         id: 'project-id',
-        slug: projectSlug,
       });
 
       mockPrismaService.projectPlatform.findUnique.mockResolvedValue({
@@ -109,7 +108,7 @@ describe('MessagesService', () => {
         status: 'waiting',
       });
 
-      const result = await service.sendMessage(projectSlug, sendMessageDto);
+      const result = await service.sendMessage(projectId, sendMessageDto);
 
       expect(result).toHaveProperty('success', true);
       expect(result).toHaveProperty('jobId', 'job-123');
@@ -117,14 +116,13 @@ describe('MessagesService', () => {
       expect(result).toHaveProperty('platformIds');
       expect(result.platformIds).toContain('platform-uuid-123');
       expect(mockMessageQueue.addMessage).toHaveBeenCalledWith({
-        projectSlug,
         projectId: 'project-id',
         message: sendMessageDto,
       });
     });
 
     it('should queue message for Telegram platform', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const sendMessageDto = {
         targets: [
           {
@@ -138,7 +136,6 @@ describe('MessagesService', () => {
 
       mockPrismaService.project.findUnique.mockResolvedValue({
         id: 'project-id',
-        slug: projectSlug,
       });
 
       mockPrismaService.projectPlatform.findUnique.mockResolvedValue({
@@ -153,7 +150,7 @@ describe('MessagesService', () => {
         status: 'waiting',
       });
 
-      const result = await service.sendMessage(projectSlug, sendMessageDto);
+      const result = await service.sendMessage(projectId, sendMessageDto);
 
       expect(result).toHaveProperty('success', true);
       expect(result).toHaveProperty('jobId', 'job-456');
@@ -161,7 +158,6 @@ describe('MessagesService', () => {
       expect(result.platformIds).toContain('platform-uuid-456');
       expect(result).toHaveProperty('status', 'waiting');
       expect(mockMessageQueue.addMessage).toHaveBeenCalledWith({
-        projectSlug,
         projectId: 'project-id',
         message: sendMessageDto,
       });
@@ -181,7 +177,7 @@ describe('MessagesService', () => {
     });
 
     it('should throw NotFoundException when platform is not configured', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const sendMessageDto = {
         targets: [
           {
@@ -195,7 +191,6 @@ describe('MessagesService', () => {
 
       mockPrismaService.project.findUnique.mockResolvedValue({
         id: 'project-id',
-        slug: projectSlug,
       });
 
       mockPlatformsService.validatePlatformConfigById.mockRejectedValue(
@@ -205,12 +200,12 @@ describe('MessagesService', () => {
       );
 
       await expect(
-        service.sendMessage(projectSlug, sendMessageDto),
+        service.sendMessage(projectId, sendMessageDto),
       ).rejects.toThrow(NotFoundException);
     });
 
     it('should throw BadRequestException when platform is disabled', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const sendMessageDto = {
         targets: [
           {
@@ -224,7 +219,6 @@ describe('MessagesService', () => {
 
       mockPrismaService.project.findUnique.mockResolvedValue({
         id: 'project-id',
-        slug: projectSlug,
       });
 
       mockPlatformsService.validatePlatformConfigById.mockRejectedValue(
@@ -234,7 +228,7 @@ describe('MessagesService', () => {
       );
 
       await expect(
-        service.sendMessage(projectSlug, sendMessageDto),
+        service.sendMessage(projectId, sendMessageDto),
       ).rejects.toThrow(BadRequestException);
     });
   });

--- a/src/platforms/platforms.controller.ts
+++ b/src/platforms/platforms.controller.ts
@@ -19,7 +19,7 @@ import { AuthContextParam } from '../common/decorators/auth-context.decorator';
 import type { AuthContext } from '../common/utils/security.util';
 import { ApiScope } from '../common/enums/api-scopes.enum';
 
-@Controller('api/v1/projects/:projectSlug/platforms')
+@Controller('api/v1/projects/:project/platforms')
 @UseGuards(AppAuthGuard, ProjectAccessGuard)
 export class PlatformsController {
   constructor(private readonly platformsService: PlatformsService) {}
@@ -85,12 +85,12 @@ export class PlatformsController {
     ],
   })
   create(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Body() createPlatformDto: CreatePlatformDto,
     @AuthContextParam() authContext: AuthContext,
   ) {
     return this.platformsService.create(
-      projectSlug,
+      project,
       createPlatformDto,
       authContext,
     );
@@ -111,8 +111,8 @@ export class PlatformsController {
       },
     ],
   })
-  findAll(@Param('projectSlug') projectSlug: string) {
-    return this.platformsService.findAll(projectSlug);
+  findAll(@Param('project') project: string) {
+    return this.platformsService.findAll(project);
   }
 
   @Get(':id')
@@ -133,8 +133,8 @@ export class PlatformsController {
       },
     ],
   })
-  findOne(@Param('projectSlug') projectSlug: string, @Param('id') id: string) {
-    return this.platformsService.findOne(projectSlug, id);
+  findOne(@Param('project') project: string, @Param('id') id: string) {
+    return this.platformsService.findOne(project, id);
   }
 
   @Patch(':id')
@@ -186,11 +186,11 @@ export class PlatformsController {
     ],
   })
   update(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('id') id: string,
     @Body() updatePlatformDto: UpdatePlatformDto,
   ) {
-    return this.platformsService.update(projectSlug, id, updatePlatformDto);
+    return this.platformsService.update(project, id, updatePlatformDto);
   }
 
   @Delete(':id')
@@ -211,8 +211,8 @@ export class PlatformsController {
       },
     ],
   })
-  remove(@Param('projectSlug') projectSlug: string, @Param('id') id: string) {
-    return this.platformsService.remove(projectSlug, id);
+  remove(@Param('project') project: string, @Param('id') id: string) {
+    return this.platformsService.remove(project, id);
   }
 
   @Post(':id/register-webhook')
@@ -234,10 +234,10 @@ export class PlatformsController {
     ],
   })
   async registerWebhook(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('id') id: string,
   ) {
-    return this.platformsService.registerWebhook(projectSlug, id);
+    return this.platformsService.registerWebhook(project, id);
   }
 
   @Get(':id/qr-code')
@@ -262,10 +262,7 @@ export class PlatformsController {
       },
     ],
   })
-  async getQRCode(
-    @Param('projectSlug') projectSlug: string,
-    @Param('id') id: string,
-  ) {
-    return this.platformsService.getQRCode(projectSlug, id);
+  async getQRCode(@Param('project') project: string, @Param('id') id: string) {
+    return this.platformsService.getQRCode(project, id);
   }
 }

--- a/src/platforms/platforms.service.spec.ts
+++ b/src/platforms/platforms.service.spec.ts
@@ -19,7 +19,7 @@ describe('PlatformsService', () => {
 
   const mockAuthContext = {
     authType: 'api-key' as const,
-    project: { id: 'project-id', slug: 'test-project' },
+    project: { id: 'project-id' },
   };
 
   const mockPrismaService = {
@@ -71,7 +71,7 @@ describe('PlatformsService', () => {
 
   describe('create', () => {
     it('should create a platform configuration', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'project-id';
       const createDto = {
         platform: 'discord' as any,
         name: 'Test Discord Bot',
@@ -81,7 +81,7 @@ describe('PlatformsService', () => {
         testMode: false,
       };
 
-      const mockProject = { id: 'project-id', slug: projectSlug };
+      const mockProject = { id: 'project-id' };
       mockPrismaService.project.findUnique.mockResolvedValue(mockProject);
       mockPrismaService.projectPlatform.findUnique.mockResolvedValue(null);
       mockPrismaService.projectPlatform.create.mockResolvedValue({
@@ -97,7 +97,7 @@ describe('PlatformsService', () => {
       });
 
       const result = await service.create(
-        projectSlug,
+        projectId,
         createDto,
         mockAuthContext,
       );
@@ -242,10 +242,10 @@ describe('PlatformsService', () => {
 
   describe('findAll', () => {
     it('should return all platforms for a project', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const mockProject = {
         id: 'project-id',
-        slug: projectSlug,
+
         projectPlatforms: [
           {
             id: 'platform-1',
@@ -272,7 +272,7 @@ describe('PlatformsService', () => {
 
       mockPrismaService.project.findUnique.mockResolvedValue(mockProject);
 
-      const result = await service.findAll(projectSlug);
+      const result = await service.findAll(projectId);
 
       expect(result).toHaveLength(2);
       expect(result[0]).toHaveProperty('platform', 'discord');
@@ -297,7 +297,7 @@ describe('PlatformsService', () => {
 
   describe('findOne', () => {
     it('should return platform with decrypted credentials', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const platformId = 'platform-id';
       const mockCredentials = { token: 'discord-token' };
 
@@ -314,7 +314,7 @@ describe('PlatformsService', () => {
         updatedAt: new Date(),
       });
 
-      const result = await service.findOne(projectSlug, platformId);
+      const result = await service.findOne(projectId, platformId);
 
       expect(result).toHaveProperty('credentials');
       // Credentials should be masked in response
@@ -325,7 +325,7 @@ describe('PlatformsService', () => {
 
   describe('update', () => {
     it('should update platform configuration', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const platformId = 'platform-id';
       const updateDto = {
         credentials: { token: 'new-token' },
@@ -347,7 +347,7 @@ describe('PlatformsService', () => {
         updatedAt: new Date(),
       });
 
-      const result = await service.update(projectSlug, platformId, updateDto);
+      const result = await service.update(projectId, platformId, updateDto);
 
       expect(result).toHaveProperty('isActive', false);
       expect(mockPrismaService.projectPlatform.update).toHaveBeenCalledWith({
@@ -360,7 +360,7 @@ describe('PlatformsService', () => {
     });
 
     it('should update platform name and description', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const platformId = 'platform-id';
       const updateDto = {
         name: 'Updated Bot Name',
@@ -387,7 +387,7 @@ describe('PlatformsService', () => {
         updatedAt: new Date(),
       });
 
-      const result = await service.update(projectSlug, platformId, updateDto);
+      const result = await service.update(projectId, platformId, updateDto);
 
       expect(result).toHaveProperty('name', 'Updated Bot Name');
       expect(result).toHaveProperty(
@@ -404,7 +404,7 @@ describe('PlatformsService', () => {
     });
 
     it('should update only name (clear description)', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const platformId = 'platform-id';
       const updateDto = {
         name: 'Simple Bot',
@@ -428,7 +428,7 @@ describe('PlatformsService', () => {
         updatedAt: new Date(),
       });
 
-      const result = await service.update(projectSlug, platformId, updateDto);
+      const result = await service.update(projectId, platformId, updateDto);
 
       expect(result).toHaveProperty('name', 'Simple Bot');
       expect(result).toHaveProperty('description', null);
@@ -442,7 +442,7 @@ describe('PlatformsService', () => {
     });
 
     it('should update only name without changing isActive or testMode', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const platformId = 'platform-id';
       const updateDto = {
         name: 'New Name Only',
@@ -470,7 +470,7 @@ describe('PlatformsService', () => {
         updatedAt: new Date(),
       });
 
-      await service.update(projectSlug, platformId, updateDto);
+      await service.update(projectId, platformId, updateDto);
 
       // Verify that ONLY name is in the update data
       const updateCall =
@@ -483,7 +483,7 @@ describe('PlatformsService', () => {
     });
 
     it('should update only credentials without changing isActive', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const platformId = 'platform-id';
       const updateDto = {
         credentials: { token: 'new-token' },
@@ -510,7 +510,7 @@ describe('PlatformsService', () => {
         updatedAt: new Date(),
       });
 
-      await service.update(projectSlug, platformId, updateDto);
+      await service.update(projectId, platformId, updateDto);
 
       // Verify that ONLY credentialsEncrypted is in the update data
       const updateCall =
@@ -523,7 +523,7 @@ describe('PlatformsService', () => {
     });
 
     it('should update only description without changing other fields', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const platformId = 'platform-id';
       const updateDto = {
         description: 'New description',
@@ -552,7 +552,7 @@ describe('PlatformsService', () => {
         updatedAt: new Date(),
       });
 
-      await service.update(projectSlug, platformId, updateDto);
+      await service.update(projectId, platformId, updateDto);
 
       // Verify that ONLY description is in the update data
       const updateCall =
@@ -567,7 +567,7 @@ describe('PlatformsService', () => {
 
   describe('remove', () => {
     it('should remove platform configuration', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const platformId = 'platform-id';
 
       mockPrismaService.project.findUnique.mockResolvedValue({
@@ -580,7 +580,7 @@ describe('PlatformsService', () => {
         webhookToken: 'webhook-token',
       });
 
-      const result = await service.remove(projectSlug, platformId);
+      const result = await service.remove(projectId, platformId);
 
       expect(result).toHaveProperty('message', 'Platform removed successfully');
       expect(mockPrismaService.projectPlatform.delete).toHaveBeenCalledWith({
@@ -601,7 +601,7 @@ describe('PlatformsService', () => {
     });
 
     it('should fire created event when platform is created and active', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const createDto = {
         platform: 'whatsapp-evo',
         credentials: {
@@ -623,7 +623,7 @@ describe('PlatformsService', () => {
         updatedAt: new Date(),
       });
 
-      await service.create(projectSlug, createDto, mockAuthContext);
+      await service.create(projectId, createDto, mockAuthContext);
 
       expect(mockProvider.onPlatformEvent).toHaveBeenCalledWith({
         type: 'created',
@@ -636,7 +636,7 @@ describe('PlatformsService', () => {
     });
 
     it('should not fire created event when platform is created but inactive', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const createDto = {
         platform: 'whatsapp-evo',
         credentials: {
@@ -658,13 +658,13 @@ describe('PlatformsService', () => {
         updatedAt: new Date(),
       });
 
-      await service.create(projectSlug, createDto, mockAuthContext);
+      await service.create(projectId, createDto, mockAuthContext);
 
       expect(mockProvider.onPlatformEvent).not.toHaveBeenCalled();
     });
 
     it('should fire activated event when platform is activated', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const platformId = 'platform-id';
       const updateDto = { isActive: true };
 
@@ -687,7 +687,7 @@ describe('PlatformsService', () => {
         updatedAt: new Date(),
       });
 
-      await service.update(projectSlug, platformId, updateDto);
+      await service.update(projectId, platformId, updateDto);
 
       expect(mockProvider.onPlatformEvent).toHaveBeenCalledWith({
         type: 'activated',
@@ -703,7 +703,7 @@ describe('PlatformsService', () => {
     });
 
     it('should fire deactivated event when platform is deactivated', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const platformId = 'platform-id';
       const updateDto = { isActive: false };
 
@@ -726,7 +726,7 @@ describe('PlatformsService', () => {
         updatedAt: new Date(),
       });
 
-      await service.update(projectSlug, platformId, updateDto);
+      await service.update(projectId, platformId, updateDto);
 
       expect(mockProvider.onPlatformEvent).toHaveBeenCalledWith({
         type: 'deactivated',
@@ -742,7 +742,7 @@ describe('PlatformsService', () => {
     });
 
     it('should fire deleted event when platform is removed', async () => {
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const platformId = 'platform-id';
 
       mockPrismaService.project.findUnique.mockResolvedValue({
@@ -756,7 +756,7 @@ describe('PlatformsService', () => {
         webhookToken: 'webhook-token',
       });
 
-      await service.remove(projectSlug, platformId);
+      await service.remove(projectId, platformId);
 
       expect(mockProvider.onPlatformEvent).toHaveBeenCalledWith({
         type: 'deleted',
@@ -774,7 +774,7 @@ describe('PlatformsService', () => {
     it('should handle missing provider gracefully', async () => {
       mockPlatformRegistry.getProvider.mockReturnValue(null);
 
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const createDto = {
         platform: 'unknown-platform',
         credentials: {},
@@ -795,7 +795,7 @@ describe('PlatformsService', () => {
 
       // Should not throw even if provider doesn't exist
       await expect(
-        service.create(projectSlug, createDto, mockAuthContext),
+        service.create(projectId, createDto, mockAuthContext),
       ).resolves.toBeDefined();
     });
 
@@ -803,7 +803,7 @@ describe('PlatformsService', () => {
       const providerWithoutEvents = { name: 'simple-provider' };
       mockPlatformRegistry.getProvider.mockReturnValue(providerWithoutEvents);
 
-      const projectSlug = 'test-project';
+      const projectId = 'test-project';
       const createDto = {
         platform: 'simple-platform',
         credentials: {},
@@ -824,7 +824,7 @@ describe('PlatformsService', () => {
 
       // Should not throw even if provider doesn't support events
       await expect(
-        service.create(projectSlug, createDto, mockAuthContext),
+        service.create(projectId, createDto, mockAuthContext),
       ).resolves.toBeDefined();
     });
   });

--- a/src/platforms/platforms.service.ts
+++ b/src/platforms/platforms.service.ts
@@ -66,14 +66,14 @@ export class PlatformsService {
   }
 
   async create(
-    projectSlug: string,
+    projectId: string,
     createPlatformDto: CreatePlatformDto,
     authContext: AuthContext,
   ) {
     // Get project and validate access in one step
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'platform creation',
     );
@@ -128,18 +128,16 @@ export class PlatformsService {
     };
   }
 
-  async findAll(projectSlug: string) {
+  async findAll(projectId: string) {
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
       include: {
         projectPlatforms: true,
       },
     });
 
     if (!project) {
-      throw new NotFoundException(
-        `Project with slug '${projectSlug}' not found`,
-      );
+      throw new NotFoundException(`Project '${projectId}' not found`);
     }
 
     return project.projectPlatforms.map((platform) => ({
@@ -155,15 +153,13 @@ export class PlatformsService {
     }));
   }
 
-  async findOne(projectSlug: string, platformId: string) {
+  async findOne(projectId: string, platformId: string) {
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
     });
 
     if (!project) {
-      throw new NotFoundException(
-        `Project with slug '${projectSlug}' not found`,
-      );
+      throw new NotFoundException(`Project '${projectId}' not found`);
     }
 
     const platform = await this.prisma.projectPlatform.findFirst({
@@ -199,18 +195,16 @@ export class PlatformsService {
   }
 
   async update(
-    projectSlug: string,
+    projectId: string,
     platformId: string,
     updatePlatformDto: UpdatePlatformDto,
   ) {
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
     });
 
     if (!project) {
-      throw new NotFoundException(
-        `Project with slug '${projectSlug}' not found`,
-      );
+      throw new NotFoundException(`Project '${projectId}' not found`);
     }
 
     const existingPlatform = await this.prisma.projectPlatform.findFirst({
@@ -308,15 +302,13 @@ export class PlatformsService {
     };
   }
 
-  async remove(projectSlug: string, platformId: string) {
+  async remove(projectId: string, platformId: string) {
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
     });
 
     if (!project) {
-      throw new NotFoundException(
-        `Project with slug '${projectSlug}' not found`,
-      );
+      throw new NotFoundException(`Project '${projectId}' not found`);
     }
 
     const platform = await this.prisma.projectPlatform.findFirst({
@@ -480,15 +472,13 @@ export class PlatformsService {
     }
   }
 
-  async registerWebhook(projectSlug: string, platformId: string) {
+  async registerWebhook(projectId: string, platformId: string) {
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
     });
 
     if (!project) {
-      throw new NotFoundException(
-        `Project with slug '${projectSlug}' not found`,
-      );
+      throw new NotFoundException(`Project '${projectId}' not found`);
     }
 
     const platform = await this.prisma.projectPlatform.findFirst({
@@ -575,15 +565,13 @@ export class PlatformsService {
     }
   }
 
-  async getQRCode(projectSlug: string, platformId: string) {
+  async getQRCode(projectId: string, platformId: string) {
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
     });
 
     if (!project) {
-      throw new NotFoundException(
-        `Project with slug '${projectSlug}' not found`,
-      );
+      throw new NotFoundException(`Project '${projectId}' not found`);
     }
 
     const platform = await this.prisma.projectPlatform.findFirst({

--- a/src/platforms/providers/discord.provider.spec.ts
+++ b/src/platforms/providers/discord.provider.spec.ts
@@ -368,7 +368,7 @@ describe('DiscordProvider', () => {
           project: {
             select: {
               id: true,
-              slug: true,
+              name: true,
             },
           },
         },

--- a/src/platforms/providers/discord.provider.ts
+++ b/src/platforms/providers/discord.provider.ts
@@ -112,7 +112,7 @@ export class DiscordProvider
           project: {
             select: {
               id: true,
-              slug: true,
+              name: true,
             },
           },
         },
@@ -135,7 +135,7 @@ export class DiscordProvider
 
           await this.createAdapter(connectionKey, credentials);
           this.logger.log(
-            `Discord bot auto-connected for project ${platform.project.slug} (${connectionKey})`,
+            `Discord bot auto-connected for project ${platform.project.id} (${connectionKey})`,
           );
         } catch (error) {
           this.logger.error(

--- a/src/platforms/providers/telegram.provider.ts
+++ b/src/platforms/providers/telegram.provider.ts
@@ -263,7 +263,7 @@ export class TelegramProvider implements PlatformProvider, PlatformAdapter {
         );
         const update = body as TelegramBot.Update;
         platformLogger.logWebhook(
-          `Processed Telegram webhook for project: ${platformConfig.project.slug}`,
+          `Processed Telegram webhook for project: ${platformConfig.project.id}`,
           {
             updateType: update.message
               ? 'message'
@@ -279,7 +279,7 @@ export class TelegramProvider implements PlatformProvider, PlatformAdapter {
         );
 
         this.logger.log(
-          `Processed Telegram webhook for project: ${platformConfig.project.slug}`,
+          `Processed Telegram webhook for project: ${platformConfig.project.id}`,
         );
 
         return { ok: true };

--- a/src/platforms/providers/whatsapp.provider.ts
+++ b/src/platforms/providers/whatsapp.provider.ts
@@ -342,7 +342,7 @@ export class WhatsAppProvider implements PlatformProvider, PlatformAdapter {
           platformConfig.id,
         );
         platformLogger.logWebhook(
-          `Processed WhatsApp webhook for project: ${platformConfig.project.slug}`,
+          `Processed WhatsApp webhook for project: ${platformConfig.project.id}`,
           {
             event: body.event || 'unknown',
             instanceName: body.instance || 'unknown',
@@ -350,7 +350,7 @@ export class WhatsAppProvider implements PlatformProvider, PlatformAdapter {
         );
 
         this.logger.log(
-          `Processed WhatsApp webhook for project: ${platformConfig.project.slug}`,
+          `Processed WhatsApp webhook for project: ${platformConfig.project.id}`,
         );
         return { ok: true };
       },

--- a/src/prisma/seed.service.ts
+++ b/src/prisma/seed.service.ts
@@ -15,7 +15,7 @@ export class SeedService implements OnModuleInit {
   private async seedDatabase() {
     try {
       const existingProject = await this.prisma.project.findUnique({
-        where: { slug: 'default' },
+        where: { id: 'default' },
       });
 
       if (!existingProject) {
@@ -42,7 +42,7 @@ export class SeedService implements OnModuleInit {
             name: 'Default Project',
             description:
               'Default development project for testing and initial setup',
-            slug: 'default',
+            id: 'default',
             environment: 'development',
             isDefault: true,
             ownerId: systemUser.id,

--- a/src/projects/dto/create-project.dto.ts
+++ b/src/projects/dto/create-project.dto.ts
@@ -17,7 +17,7 @@ export class CreateProjectDto {
 
   @IsOptional()
   @IsString()
-  slug?: string;
+  id?: string;
 
   @IsOptional()
   @IsEnum(ProjectEnvironment)

--- a/src/projects/dto/project-response.dto.ts
+++ b/src/projects/dto/project-response.dto.ts
@@ -2,7 +2,6 @@ export class ProjectResponse {
   id: string;
   name: string;
   description?: string;
-  slug: string;
   environment: 'development' | 'staging' | 'production';
   isDefault: boolean;
   settings?: Record<string, unknown>;

--- a/src/projects/dto/update-project.dto.ts
+++ b/src/projects/dto/update-project.dto.ts
@@ -18,7 +18,7 @@ export class UpdateProjectDto {
 
   @IsOptional()
   @IsString()
-  slug?: string;
+  id?: string;
 
   @IsOptional()
   @IsEnum(ProjectEnvironment)

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -99,11 +99,11 @@ export class ProjectsController {
     return [req.project];
   }
 
-  @Get(':slug')
+  @Get(':project')
   @RequireScopes(ApiScope.PROJECTS_READ)
   @SdkContract({
     command: 'projects get',
-    description: 'Get project details by slug',
+    description: 'Get project details',
     category: 'Projects',
     requiredScopes: [ApiScope.PROJECTS_READ],
     outputType: 'ProjectResponse',
@@ -114,11 +114,11 @@ export class ProjectsController {
       },
     ],
   })
-  findOne(@Param('slug') slug: string) {
-    return this.projectsService.findOne(slug);
+  findOne(@Param('project') project: string) {
+    return this.projectsService.findOne(project);
   }
 
-  @Patch(':slug')
+  @Patch(':project')
   @RequireScopes(ApiScope.PROJECTS_WRITE)
   @SdkContract({
     command: 'projects update',
@@ -155,13 +155,13 @@ export class ProjectsController {
     ],
   })
   update(
-    @Param('slug') slug: string,
+    @Param('project') project: string,
     @Body() updateProjectDto: UpdateProjectDto,
   ) {
-    return this.projectsService.update(slug, updateProjectDto);
+    return this.projectsService.update(project, updateProjectDto);
   }
 
-  @Delete(':slug')
+  @Delete(':project')
   @RequireScopes(ApiScope.PROJECTS_WRITE)
   @SdkContract({
     command: 'projects delete',
@@ -176,10 +176,10 @@ export class ProjectsController {
       },
     ],
   })
-  remove(@Param('slug') slug: string, @Request() req: any) {
+  remove(@Param('project') project: string, @Request() req: any) {
     if (req.authType === 'jwt') {
       return this.projectsService.remove(
-        slug,
+        project,
         req.user.user.id,
         req.user.user.isAdmin,
       );

--- a/src/projects/projects.service.spec.ts
+++ b/src/projects/projects.service.spec.ts
@@ -112,7 +112,7 @@ describe('ProjectsService', () => {
       expect(mockPrismaService.project.create).toHaveBeenCalledWith({
         data: {
           name: createDto.name,
-          slug: expect.any(String),
+          id: expect.any(String),
           environment: createDto.environment,
           isDefault: createDto.isDefault,
           settings: undefined,
@@ -241,7 +241,7 @@ describe('ProjectsService', () => {
       const result = await service.findOne('test-project');
 
       expect(mockPrismaService.project.findUnique).toHaveBeenCalledWith({
-        where: { slug: 'test-project' },
+        where: { id: 'test-project' },
         include: {
           apiKeys: {
             where: { revokedAt: null },
@@ -289,12 +289,12 @@ describe('ProjectsService', () => {
       );
     });
 
-    it('should throw ConflictException when updating to existing slug', async () => {
-      const updateDto = { slug: 'existing-slug' };
+    it('should throw ConflictException when updating to existing id', async () => {
+      const updateDto = { id: 'existing-id' };
 
       mockPrismaService.project.findUnique
-        .mockResolvedValueOnce({ id: 'project-id', slug: 'test-project' })
-        .mockResolvedValueOnce({ id: 'another-id', slug: 'existing-slug' });
+        .mockResolvedValueOnce({ id: 'test-project' })
+        .mockResolvedValueOnce({ id: 'existing-id' });
 
       await expect(service.update('test-project', updateDto)).rejects.toThrow(
         ConflictException,
@@ -315,7 +315,7 @@ describe('ProjectsService', () => {
       const result = await service.remove('test-project', 'user-1', false);
 
       expect(mockPrismaService.project.delete).toHaveBeenCalledWith({
-        where: { slug: 'test-project' },
+        where: { id: 'test-project' },
       });
       expect(result).toEqual(projectToDelete);
     });

--- a/src/queues/message.queue.ts
+++ b/src/queues/message.queue.ts
@@ -9,7 +9,6 @@ import type { Queue } from 'bullmq';
 import { SendMessageDto } from '../platforms/dto/send-message.dto';
 
 export interface MessageJobData {
-  projectSlug: string;
   projectId: string;
   message: SendMessageDto;
   attemptNumber?: number;

--- a/src/queues/processors/dynamic-message.processor.spec.ts
+++ b/src/queues/processors/dynamic-message.processor.spec.ts
@@ -90,7 +90,7 @@ describe('DynamicMessageProcessor', () => {
       const mockJob = {
         id: 'test-job-1',
         data: {
-          projectSlug: 'test-project',
+          projectId: 'project-id',
           projectId: 'project-id',
           message: {
             targets: [
@@ -144,7 +144,7 @@ describe('DynamicMessageProcessor', () => {
       const mockJob = {
         id: 'test-job-2',
         data: {
-          projectSlug: 'test-project',
+          projectId: 'project-id',
           projectId: 'project-id',
           message: {
             targets: [
@@ -200,7 +200,7 @@ describe('DynamicMessageProcessor', () => {
       const mockJob = {
         id: 'test-job-multi',
         data: {
-          projectSlug: 'test-project',
+          projectId: 'project-id',
           projectId: 'project-id',
           message: {
             targets: [
@@ -275,7 +275,7 @@ describe('DynamicMessageProcessor', () => {
       const mockJob = {
         id: 'test-job-success',
         data: {
-          projectSlug: 'test-project',
+          projectId: 'project-id',
           projectId: 'project-id',
           message: {
             targets: [
@@ -344,7 +344,7 @@ describe('DynamicMessageProcessor', () => {
       const mockJob = {
         id: 'test-job-permanent-fail',
         data: {
-          projectSlug: 'test-project',
+          projectId: 'project-id',
           projectId: 'project-id',
           message: {
             targets: [
@@ -409,7 +409,7 @@ describe('DynamicMessageProcessor', () => {
       const mockJob = {
         id: 'test-job-missing-config',
         data: {
-          projectSlug: 'test-project',
+          projectId: 'project-id',
           projectId: 'project-id',
           message: {
             targets: [
@@ -446,7 +446,7 @@ describe('DynamicMessageProcessor', () => {
       const mockJob = {
         id: 'test-job-db-error',
         data: {
-          projectSlug: 'test-project',
+          projectId: 'project-id',
           projectId: 'project-id',
           message: {
             targets: [
@@ -484,7 +484,7 @@ describe('DynamicMessageProcessor', () => {
       const mockJob = {
         id: 'test-job-duplicates',
         data: {
-          projectSlug: 'test-project',
+          projectId: 'project-id',
           projectId: 'project-id',
           message: {
             targets: [

--- a/src/queues/processors/dynamic-message.processor.ts
+++ b/src/queues/processors/dynamic-message.processor.ts
@@ -14,7 +14,6 @@ import { WebhookDeliveryService } from '../../webhooks/services/webhook-delivery
 import { WebhookEventType } from '../../webhooks/types/webhook-event.types';
 
 interface MessageJob {
-  projectSlug: string;
   projectId: string;
   message: {
     targets: Array<{
@@ -65,7 +64,7 @@ export class DynamicMessageProcessor
 
   // BullMQ WorkerHost requires this method name
   async process(job: Job<MessageJob>) {
-    const { projectSlug, projectId, message } = job.data;
+    const { projectId, message } = job.data;
 
     // SECURITY: Deduplicate targets to prevent spam attacks
     const targetMap = new Map<string, (typeof message.targets)[0]>();

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -17,7 +17,7 @@ import { AddMemberDto } from './dto/add-member.dto';
 import { UpdateMemberRoleDto } from './dto/update-member-role.dto';
 import { ApiScope } from '../common/enums/api-scopes.enum';
 
-@Controller('api/v1/projects/:slug/members')
+@Controller('api/v1/projects/:project/members')
 @UseGuards(AppAuthGuard)
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
@@ -37,8 +37,8 @@ export class UsersController {
       },
     ],
   })
-  async listMembers(@Param('slug') slug: string, @Request() req: any) {
-    return this.usersService.getProjectMembers(slug, req.user.userId);
+  async listMembers(@Param('project') project: string, @Request() req: any) {
+    return this.usersService.getProjectMembers(project, req.user.userId);
   }
 
   @Post()
@@ -77,12 +77,12 @@ export class UsersController {
     ],
   })
   async addMember(
-    @Param('slug') slug: string,
+    @Param('project') project: string,
     @Body() dto: AddMemberDto,
     @Request() req: any,
   ) {
     return this.usersService.addProjectMember(
-      slug,
+      project,
       dto.email,
       dto.role,
       req.user.userId,
@@ -123,13 +123,13 @@ export class UsersController {
     ],
   })
   async updateMemberRole(
-    @Param('slug') slug: string,
+    @Param('project') project: string,
     @Param('userId') userId: string,
     @Body() dto: UpdateMemberRoleDto,
     @Request() req: any,
   ) {
     return this.usersService.updateProjectMemberRole(
-      slug,
+      project,
       userId,
       dto.role,
       req.user.userId,
@@ -159,10 +159,14 @@ export class UsersController {
     ],
   })
   async removeMember(
-    @Param('slug') slug: string,
+    @Param('project') project: string,
     @Param('userId') userId: string,
     @Request() req: any,
   ) {
-    return this.usersService.removeProjectMember(slug, userId, req.user.userId);
+    return this.usersService.removeProjectMember(
+      project,
+      userId,
+      req.user.userId,
+    );
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -65,11 +65,11 @@ export class UsersService {
 
   async checkProjectAccess(
     userId: string,
-    projectSlug: string,
+    projectId: string,
     requiredRole?: ProjectRole,
   ): Promise<boolean> {
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
       include: {
         owner: true,
         members: {
@@ -182,7 +182,7 @@ export class UsersService {
   }
 
   async addProjectMember(
-    projectSlug: string,
+    projectId: string,
     userEmail: string,
     role: ProjectRole,
     requesterId: string,
@@ -190,7 +190,7 @@ export class UsersService {
     // Verify requester has admin access
     const hasAccess = await this.checkProjectAccess(
       requesterId,
-      projectSlug,
+      projectId,
       ProjectRole.admin,
     );
     if (!hasAccess) {
@@ -210,13 +210,11 @@ export class UsersService {
 
     // Get the project
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
     });
 
     if (!project) {
-      throw new NotFoundException(
-        `Project with slug '${projectSlug}' not found`,
-      );
+      throw new NotFoundException(`Project '${projectId}' not found`);
     }
 
     // Add or update membership
@@ -246,14 +244,14 @@ export class UsersService {
   }
 
   async removeProjectMember(
-    projectSlug: string,
+    projectId: string,
     userId: string,
     requesterId: string,
   ) {
     // Verify requester has admin access
     const hasAccess = await this.checkProjectAccess(
       requesterId,
-      projectSlug,
+      projectId,
       ProjectRole.admin,
     );
     if (!hasAccess) {
@@ -263,13 +261,11 @@ export class UsersService {
     }
 
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
     });
 
     if (!project) {
-      throw new NotFoundException(
-        `Project with slug '${projectSlug}' not found`,
-      );
+      throw new NotFoundException(`Project '${projectId}' not found`);
     }
 
     // Cannot remove the project owner
@@ -288,7 +284,7 @@ export class UsersService {
   }
 
   async updateProjectMemberRole(
-    projectSlug: string,
+    projectId: string,
     userId: string,
     role: ProjectRole,
     requesterId: string,
@@ -296,7 +292,7 @@ export class UsersService {
     // Verify requester has admin access
     const hasAccess = await this.checkProjectAccess(
       requesterId,
-      projectSlug,
+      projectId,
       ProjectRole.admin,
     );
     if (!hasAccess) {
@@ -306,13 +302,11 @@ export class UsersService {
     }
 
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
     });
 
     if (!project) {
-      throw new NotFoundException(
-        `Project with slug '${projectSlug}' not found`,
-      );
+      throw new NotFoundException(`Project '${projectId}' not found`);
     }
 
     // Cannot change role of project owner
@@ -340,11 +334,11 @@ export class UsersService {
     });
   }
 
-  async getProjectMembers(projectSlug: string, requesterId: string) {
+  async getProjectMembers(projectId: string, requesterId: string) {
     // Verify requester has read access
     const hasAccess = await this.checkProjectAccess(
       requesterId,
-      projectSlug,
+      projectId,
       ProjectRole.viewer,
     );
     if (!hasAccess) {
@@ -354,7 +348,7 @@ export class UsersService {
     }
 
     const project = await this.prisma.project.findUnique({
-      where: { slug: projectSlug },
+      where: { id: projectId },
       include: {
         owner: {
           select: {
@@ -378,9 +372,7 @@ export class UsersService {
     });
 
     if (!project) {
-      throw new NotFoundException(
-        `Project with slug '${projectSlug}' not found`,
-      );
+      throw new NotFoundException(`Project '${projectId}' not found`);
     }
 
     // Include project owner as a member with owner role

--- a/src/webhooks/services/webhooks.service.ts
+++ b/src/webhooks/services/webhooks.service.ts
@@ -25,14 +25,14 @@ export class WebhooksService {
    * Create a new webhook
    */
   async createWebhook(
-    projectSlug: string,
+    projectId: string,
     dto: CreateWebhookDto,
     authContext: AuthContext,
   ) {
     // Validate project access
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'webhook creation',
     );
@@ -77,10 +77,10 @@ export class WebhooksService {
   /**
    * List all webhooks for a project
    */
-  async listWebhooks(projectSlug: string, authContext: AuthContext) {
+  async listWebhooks(projectId: string, authContext: AuthContext) {
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'webhook listing',
     );
@@ -111,13 +111,13 @@ export class WebhooksService {
    * Get a specific webhook
    */
   async getWebhook(
-    projectSlug: string,
+    projectId: string,
     webhookId: string,
     authContext: AuthContext,
   ) {
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'webhook retrieval',
     );
@@ -149,14 +149,14 @@ export class WebhooksService {
    * Update a webhook
    */
   async updateWebhook(
-    projectSlug: string,
+    projectId: string,
     webhookId: string,
     dto: UpdateWebhookDto,
     authContext: AuthContext,
   ) {
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'webhook update',
     );
@@ -193,13 +193,13 @@ export class WebhooksService {
    * Delete a webhook
    */
   async deleteWebhook(
-    projectSlug: string,
+    projectId: string,
     webhookId: string,
     authContext: AuthContext,
   ) {
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'webhook deletion',
     );
@@ -230,14 +230,14 @@ export class WebhooksService {
    * Get webhook deliveries with filtering
    */
   async getDeliveries(
-    projectSlug: string,
+    projectId: string,
     webhookId: string,
     query: QueryDeliveriesDto,
     authContext: AuthContext,
   ) {
     const project = await SecurityUtil.getProjectWithAccess(
       this.prisma,
-      projectSlug,
+      projectId,
       authContext,
       'webhook delivery retrieval',
     );

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -22,7 +22,7 @@ import { SdkContract } from '../common/decorators/sdk-contract.decorator';
 import { WebhookEventType } from './types/webhook-event.types';
 import { ApiScope } from '../common/enums/api-scopes.enum';
 
-@Controller('api/v1/projects/:projectSlug/webhooks')
+@Controller('api/v1/projects/:project/webhooks')
 @UseGuards(AppAuthGuard, ProjectAccessGuard)
 export class WebhooksController {
   constructor(private readonly webhooksService: WebhooksService) {}
@@ -77,12 +77,12 @@ export class WebhooksController {
     ],
   })
   async createWebhook(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Body() createWebhookDto: CreateWebhookDto,
     @AuthContextParam() authContext: AuthContext,
   ) {
     return this.webhooksService.createWebhook(
-      projectSlug,
+      project,
       createWebhookDto,
       authContext,
     );
@@ -104,10 +104,10 @@ export class WebhooksController {
     ],
   })
   async listWebhooks(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @AuthContextParam() authContext: AuthContext,
   ) {
-    return this.webhooksService.listWebhooks(projectSlug, authContext);
+    return this.webhooksService.listWebhooks(project, authContext);
   }
 
   @Get(':webhookId')
@@ -133,11 +133,11 @@ export class WebhooksController {
     ],
   })
   async getWebhook(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('webhookId') webhookId: string,
     @AuthContextParam() authContext: AuthContext,
   ) {
-    return this.webhooksService.getWebhook(projectSlug, webhookId, authContext);
+    return this.webhooksService.getWebhook(project, webhookId, authContext);
   }
 
   @Patch(':webhookId')
@@ -186,13 +186,13 @@ export class WebhooksController {
     ],
   })
   async updateWebhook(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('webhookId') webhookId: string,
     @Body() updateWebhookDto: UpdateWebhookDto,
     @AuthContextParam() authContext: AuthContext,
   ) {
     return this.webhooksService.updateWebhook(
-      projectSlug,
+      project,
       webhookId,
       updateWebhookDto,
       authContext,
@@ -222,15 +222,11 @@ export class WebhooksController {
     ],
   })
   async deleteWebhook(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('webhookId') webhookId: string,
     @AuthContextParam() authContext: AuthContext,
   ) {
-    return this.webhooksService.deleteWebhook(
-      projectSlug,
-      webhookId,
-      authContext,
-    );
+    return this.webhooksService.deleteWebhook(project, webhookId, authContext);
   }
 
   @Get(':webhookId/deliveries')
@@ -281,13 +277,13 @@ export class WebhooksController {
     ],
   })
   async getDeliveries(
-    @Param('projectSlug') projectSlug: string,
+    @Param('project') project: string,
     @Param('webhookId') webhookId: string,
     @Query() query: QueryDeliveriesDto,
     @AuthContextParam() authContext: AuthContext,
   ) {
     return this.webhooksService.getDeliveries(
-      projectSlug,
+      project,
       webhookId,
       query,
       authContext,

--- a/test/fixtures/projects.fixture.ts
+++ b/test/fixtures/projects.fixture.ts
@@ -5,7 +5,7 @@ export const createTestProject = async (
   prisma: PrismaClient,
   overrides: Partial<{
     name: string;
-    slug: string;
+    id: string;
     environment: ProjectEnvironment;
     isDefault: boolean;
     settings: any;
@@ -13,7 +13,7 @@ export const createTestProject = async (
   }> = {},
 ) => {
   const name = overrides.name || 'Test Project';
-  const slug = overrides.slug || CryptoUtil.generateSlug(name);
+  const id = overrides.id || CryptoUtil.generateSlug(name);
 
   // Create or get test owner user
   let ownerId = overrides.ownerId;
@@ -33,8 +33,8 @@ export const createTestProject = async (
 
   return await prisma.project.create({
     data: {
+      id,
       name,
-      slug,
       environment: overrides.environment || 'development',
       isDefault: overrides.isDefault || false,
       settings: overrides.settings || {

--- a/test/integration/app.e2e-spec.ts
+++ b/test/integration/app.e2e-spec.ts
@@ -142,7 +142,7 @@ describe('GateKit API (e2e)', () => {
           .expect(201)
           .expect((res) => {
             expect(res.body).toHaveProperty('name', 'New Project');
-            expect(res.body).toHaveProperty('slug', 'new-project');
+            expect(res.body).toHaveProperty('id', 'new-project');
             expect(res.body).toHaveProperty('environment', 'development');
           });
       });
@@ -173,11 +173,11 @@ describe('GateKit API (e2e)', () => {
       });
 
       it('should return 409 when slug already exists', async () => {
-        await createTestProject(prisma, { name: 'Existing', slug: 'existing' });
+        await createTestProject(prisma, { name: 'Existing', id: 'existing' });
 
         const projectData = {
           name: 'Existing',
-          slug: 'existing',
+          id: 'existing',
         };
 
         return request(app.getHttpServer())
@@ -188,7 +188,7 @@ describe('GateKit API (e2e)', () => {
       });
     });
 
-    describe('GET /api/v1/projects/:slug', () => {
+    describe('GET /api/v1/projects/:project', () => {
       it('should return project details with valid API key', () => {
         return request(app.getHttpServer())
           .get('/api/v1/projects/e2e-test-project')
@@ -216,8 +216,8 @@ describe('GateKit API (e2e)', () => {
     });
   });
 
-  describe('/api/v1/projects/:slug/keys', () => {
-    describe('POST /api/v1/projects/:slug/keys', () => {
+  describe('/api/v1/projects/:project/keys', () => {
+    describe('POST /api/v1/projects/:project/keys', () => {
       it('should create a new API key with valid API key', () => {
         const keyData = {
           name: 'New API Key',
@@ -275,7 +275,7 @@ describe('GateKit API (e2e)', () => {
       });
     });
 
-    describe('GET /api/v1/projects/:slug/keys', () => {
+    describe('GET /api/v1/projects/:project/keys', () => {
       it('should list project API keys with valid API key', () => {
         return request(app.getHttpServer())
           .get('/api/v1/projects/e2e-test-project/keys')
@@ -297,7 +297,7 @@ describe('GateKit API (e2e)', () => {
       });
     });
 
-    describe('DELETE /api/v1/projects/:slug/keys/:keyId', () => {
+    describe('DELETE /api/v1/projects/:project/keys/:keyId', () => {
       it('should revoke an API key with valid API key', async () => {
         const { apiKey } = await createTestApiKey(prisma, testProjectId, {
           name: 'Key to Revoke',
@@ -329,7 +329,7 @@ describe('GateKit API (e2e)', () => {
       });
     });
 
-    describe('POST /api/v1/projects/:slug/keys/:keyId/roll', () => {
+    describe('POST /api/v1/projects/:project/keys/:keyId/roll', () => {
       it('should roll an API key with valid API key', async () => {
         const { apiKey } = await createTestApiKey(prisma, testProjectId, {
           name: 'Key to Roll',

--- a/test/integration/platforms.e2e-spec.ts
+++ b/test/integration/platforms.e2e-spec.ts
@@ -47,7 +47,7 @@ describe('Platforms (e2e)', () => {
     // Create test project and API key
     const project = await createTestProject(prisma, {
       name: 'Platform Test Project',
-      slug: 'platform-test',
+      id: 'platform-test',
     });
     testProjectId = project.id;
 
@@ -61,7 +61,7 @@ describe('Platforms (e2e)', () => {
     await app.close();
   });
 
-  describe('/api/v1/projects/:slug/platforms', () => {
+  describe('/api/v1/projects/:project/platforms', () => {
     describe('POST', () => {
       it('should create a Discord platform configuration', () => {
         return request(app.getHttpServer())
@@ -368,7 +368,7 @@ describe('Platforms (e2e)', () => {
     });
   });
 
-  describe('/api/v1/projects/:slug/messages/send', () => {
+  describe('/api/v1/projects/:project/messages/send', () => {
     beforeEach(async () => {
       // Clean and create a platform configuration
       await prisma.projectPlatform.deleteMany({

--- a/test/integration/user-projects.e2e-spec.ts
+++ b/test/integration/user-projects.e2e-spec.ts
@@ -57,7 +57,7 @@ describe('User-Project System (e2e)', () => {
     testProject = await prisma.project.create({
       data: {
         name: 'Test Project',
-        slug: 'test-project-e2e',
+        id: 'test-project-e2e',
         environment: ProjectEnvironment.development,
         ownerId: testUser1.id,
       },
@@ -147,7 +147,7 @@ describe('User-Project System (e2e)', () => {
 
       const hasAccess = await projectsService.checkProjectAccess(
         testUser1.id,
-        testProject.slug,
+        testProject.id,
         ProjectRole.admin,
         false,
       );
@@ -160,7 +160,7 @@ describe('User-Project System (e2e)', () => {
 
       const hasAccess = await projectsService.checkProjectAccess(
         testUser2.id,
-        testProject.slug,
+        testProject.id,
         ProjectRole.viewer,
         false,
       );
@@ -173,7 +173,7 @@ describe('User-Project System (e2e)', () => {
 
       const hasAccess = await projectsService.checkProjectAccess(
         adminUser.id,
-        testProject.slug,
+        testProject.id,
         ProjectRole.admin,
         true,
       );
@@ -185,7 +185,7 @@ describe('User-Project System (e2e)', () => {
       const projectsService = app.get(ProjectsService);
 
       await expect(
-        projectsService.remove(testProject.slug, testUser2.id, false),
+        projectsService.remove(testProject.id, testUser2.id, false),
       ).rejects.toThrow(
         'Only project owners or global admins can delete projects',
       );
@@ -196,7 +196,7 @@ describe('User-Project System (e2e)', () => {
       const tempProject = await prisma.project.create({
         data: {
           name: 'Temp Project',
-          slug: 'temp-project-delete',
+          id: 'temp-project-delete',
           environment: ProjectEnvironment.development,
           ownerId: testUser2.id,
         },
@@ -206,7 +206,7 @@ describe('User-Project System (e2e)', () => {
 
       // Admin should be able to delete it
       const result = await projectsService.remove(
-        tempProject.slug,
+        tempProject.id,
         adminUser.id,
         true,
       );
@@ -214,7 +214,7 @@ describe('User-Project System (e2e)', () => {
 
       // Verify it's deleted
       const deletedProject = await prisma.project.findUnique({
-        where: { slug: tempProject.slug },
+        where: { id: tempProject.id },
       });
       expect(deletedProject).toBeNull();
     });
@@ -227,7 +227,7 @@ describe('User-Project System (e2e)', () => {
       membershipTestProject = await prisma.project.create({
         data: {
           name: 'Membership Test Project',
-          slug: 'membership-test',
+          id: 'membership-test',
           environment: ProjectEnvironment.development,
           ownerId: testUser1.id,
         },
@@ -247,7 +247,7 @@ describe('User-Project System (e2e)', () => {
       const usersService = app.get(UsersService);
 
       const member = await usersService.addProjectMember(
-        membershipTestProject.slug,
+        membershipTestProject.id,
         testUser2.email,
         ProjectRole.member,
         testUser1.id,
@@ -262,7 +262,7 @@ describe('User-Project System (e2e)', () => {
       const usersService = app.get(UsersService);
 
       const updatedMember = await usersService.updateProjectMemberRole(
-        membershipTestProject.slug,
+        membershipTestProject.id,
         testUser2.id,
         ProjectRole.admin,
         testUser1.id,
@@ -276,7 +276,7 @@ describe('User-Project System (e2e)', () => {
 
       const hasAccess = await projectsService.checkProjectAccess(
         testUser2.id,
-        membershipTestProject.slug,
+        membershipTestProject.id,
         ProjectRole.member,
         false,
       );
@@ -300,7 +300,7 @@ describe('User-Project System (e2e)', () => {
       const usersService = app.get(UsersService);
 
       await usersService.removeProjectMember(
-        membershipTestProject.slug,
+        membershipTestProject.id,
         testUser2.id,
         testUser1.id,
       );
@@ -309,7 +309,7 @@ describe('User-Project System (e2e)', () => {
       const projectsService = app.get(ProjectsService);
       const hasAccess = await projectsService.checkProjectAccess(
         testUser2.id,
-        membershipTestProject.slug,
+        membershipTestProject.id,
         ProjectRole.viewer,
         false,
       );
@@ -322,7 +322,7 @@ describe('User-Project System (e2e)', () => {
 
       await expect(
         usersService.removeProjectMember(
-          membershipTestProject.slug,
+          membershipTestProject.id,
           testUser1.id, // Project owner
           testUser1.id,
         ),
@@ -334,7 +334,7 @@ describe('User-Project System (e2e)', () => {
 
       await expect(
         usersService.updateProjectMemberRole(
-          membershipTestProject.slug,
+          membershipTestProject.id,
           testUser1.id, // Project owner
           ProjectRole.member,
           testUser1.id,
@@ -378,7 +378,7 @@ describe('User-Project System (e2e)', () => {
       hierarchyTestProject = await prisma.project.create({
         data: {
           name: 'Hierarchy Test Project',
-          slug: 'hierarchy-test',
+          id: 'hierarchy-test',
           environment: ProjectEnvironment.development,
           ownerId: testUser1.id,
         },
@@ -460,7 +460,7 @@ describe('User-Project System (e2e)', () => {
 
         const hasAccess = await projectsService.checkProjectAccess(
           userId,
-          hierarchyTestProject.slug,
+          hierarchyTestProject.id,
           requiredRole as ProjectRole,
           false,
         );

--- a/test/reactions/reaction-duplicate-protection.e2e-spec.ts
+++ b/test/reactions/reaction-duplicate-protection.e2e-spec.ts
@@ -24,8 +24,7 @@ describe('Reaction Duplicate Protection (e2e)', () => {
 
   // Test fixtures
   const testProject = {
-    id: 'test-project-id',
-    slug: 'test-project',
+    id: 'test-project',
     name: 'Test Project',
     ownerId: 'test-owner',
   };

--- a/test/reactions/reaction-webhook-delivery.e2e-spec.ts
+++ b/test/reactions/reaction-webhook-delivery.e2e-spec.ts
@@ -21,8 +21,7 @@ describe('Reaction Webhook Delivery (e2e)', () => {
 
   // Test fixtures
   const testProject = {
-    id: 'test-project-webhook-id',
-    slug: 'test-project-webhook',
+    id: 'test-project-webhook',
     name: 'Test Project Webhook',
     ownerId: 'test-owner-webhook',
   };

--- a/test/test-guidelines.md
+++ b/test/test-guidelines.md
@@ -19,7 +19,11 @@ describe('Feature/Module Name', () => {
 // test/fixtures/api-keys.fixture.ts
 import { CryptoUtil } from '../../src/common/utils/crypto.util';
 
-export const createTestApiKey = async (prisma, projectId: string, overrides = {}) => {
+export const createTestApiKey = async (
+  prisma,
+  projectId: string,
+  overrides = {},
+) => {
   const environment = overrides.environment || 'test';
   const apiKey = CryptoUtil.generateApiKey(environment);
   const keyHash = CryptoUtil.hashApiKey(apiKey);
@@ -32,8 +36,8 @@ export const createTestApiKey = async (prisma, projectId: string, overrides = {}
       keyPrefix,
       name: 'Test API Key',
       environment,
-      ...overrides
-    }
+      ...overrides,
+    },
   });
 
   return { apiKey: createdKey, rawKey: apiKey };
@@ -67,8 +71,8 @@ beforeEach(async () => {
       name: 'Test Project',
       slug: 'test',
       environment: 'development',
-      isDefault: true
-    }
+      isDefault: true,
+    },
   });
 });
 
@@ -80,6 +84,7 @@ afterAll(async () => {
 ## Testing Patterns
 
 ### Testing Protected Endpoints
+
 ```typescript
 it('should return 401 when no API key provided', async () => {
   const response = await request(app.getHttpServer())
@@ -92,12 +97,13 @@ it('should return 401 when no API key provided', async () => {
 ```
 
 ### Testing Scopes
+
 ```typescript
 it('should return 403 when API key lacks required scope', async () => {
   const { rawKey } = await createTestApiKey(prisma, 'test-project-id', {
     scopes: {
-      create: [{ scope: 'messages:read' }] // Missing required scope
-    }
+      create: [{ scope: 'messages:read' }], // Missing required scope
+    },
   });
 
   const response = await request(app.getHttpServer())
@@ -111,6 +117,7 @@ it('should return 403 when API key lacks required scope', async () => {
 ```
 
 ### Testing Validation
+
 ```typescript
 it('should return 400 for invalid data', async () => {
   const response = await request(app.getHttpServer())
@@ -118,7 +125,7 @@ it('should return 400 for invalid data', async () => {
     .set('X-API-Key', validApiKey)
     .send({
       name: '', // Empty name
-      environment: 'invalid' // Invalid enum
+      environment: 'invalid', // Invalid enum
     });
 
   expect(response.status).toBe(400);
@@ -132,16 +139,16 @@ it('should return 400 for invalid data', async () => {
 // test/factories/project.factory.ts
 export const buildProject = (overrides = {}) => ({
   name: 'Test Project',
-  slug: 'test-project',
+  id: 'test-project',
   environment: 'development',
   isDefault: false,
   settings: {
     rateLimits: {
       test: 100,
-      production: 1000
-    }
+      production: 1000,
+    },
   },
-  ...overrides
+  ...overrides,
 });
 
 // test/factories/api-key.factory.ts
@@ -149,7 +156,7 @@ export const buildApiKey = (overrides = {}) => ({
   name: 'Test API Key',
   environment: 'test',
   scopes: ['messages:send', 'messages:read'],
-  ...overrides
+  ...overrides,
 });
 ```
 
@@ -163,14 +170,14 @@ export const mockPrismaService = {
     findMany: jest.fn(),
     findUnique: jest.fn(),
     update: jest.fn(),
-    delete: jest.fn()
+    delete: jest.fn(),
   },
   apiKey: {
     create: jest.fn(),
     findMany: jest.fn(),
     findUnique: jest.fn(),
-    update: jest.fn()
-  }
+    update: jest.fn(),
+  },
 };
 ```
 

--- a/tools/generators/n8n-generator.ts
+++ b/tools/generators/n8n-generator.ts
@@ -206,18 +206,18 @@ export class GateKit implements INodeType {
         );
       }
 
-      // Add path parameters (including projectSlug as parameter, not credential)
+      // Add path parameters (including project as parameter, not credential)
       const pathParams = this.extractPathParameters(contract.path);
       pathParams.forEach((param) => {
         const displayName =
-          param === 'projectSlug'
-            ? 'Project Slug'
+          param === 'project'
+            ? 'Project'
             : param.charAt(0).toUpperCase() + param.slice(1);
         const description =
-          param === 'projectSlug'
+          param === 'project'
             ? 'Project identifier to operate on'
             : `${param} parameter`;
-        const defaultValue = param === 'projectSlug' ? 'default' : '';
+        const defaultValue = param === 'project' ? 'default' : '';
 
         parameters.push(`{
           displayName: '${displayName}',
@@ -368,7 +368,7 @@ npm install n8n-nodes-gatekit
 2. **Add GateKit credentials** in n8n:
    - API URL: \`https://api.gatekit.dev\`
    - API Key: Your project API key
-   - Project Slug: Your project identifier
+   - Project: Your project identifier
 
 ## Supported Operations
 
@@ -429,11 +429,11 @@ ${operations}
 
   private convertPathForN8N(path: string): string {
     // Convert GateKit API paths to n8n format using proper n8n expression syntax
-    // /api/v1/projects/:projectSlug/messages/send -> =/api/v1/projects/{{ $parameter["projectSlug"] }}/messages/send
+    // /api/v1/projects/:project/messages/send -> =/api/v1/projects/{{ $parameter["project"] }}/messages/send
     return (
       '=' +
       path
-        .replace(':projectSlug', '{{ $parameter["projectSlug"] }}')
+        .replace(':project', '{{ $parameter["project"] }}')
         .replace(':id', '{{ $parameter["id"] }}')
         .replace(':keyId', '{{ $parameter["keyId"] }}')
         .replace(':jobId', '{{ $parameter["jobId"] }}')


### PR DESCRIPTION
## Summary

Major architectural refactoring that simplifies project identification by using slugs directly as primary keys, removing the redundant dual id/slug system.

## Database Changes
- ✅ `Project.id` is now the slug (primary key)
- ✅ Removed redundant `Project.slug` field
- ✅ Updated all foreign key references
- ✅ Migration: `20251002015312_use_slug_as_primary_key`

## API Changes
- ✅ Route parameter: `:projectSlug` → `:project`
- ✅ All endpoints use project ID/slug interchangeably
- ✅ Backward compatibility maintained

## Security Updates
- ✅ `SecurityUtil.getProjectWithAccess()` uses `projectId`
- ✅ `AuthContext.project` simplified to `{ id: string }`
- ✅ `ProjectAccessGuard` updated for new parameter
- ✅ All service method signatures updated

## Generator Updates
- ✅ **SDK**: Project parameter in options object with `defaultProject` fallback
- ✅ **CLI**: Optional `--project` flag with `GATEKIT_DEFAULT_PROJECT` env var
- ✅ **n8n**: Updated parameter names and path expressions

## Documentation
- ✅ Updated all API endpoint examples
- ✅ Revised CLAUDE.md, README.md, architecture docs
- ✅ Updated test guidelines and inline docs

## Testing
- ✅ All 544 tests passing
- ✅ Updated test fixtures
- ✅ Security coverage maintained

## Breaking Changes
⚠️ **API clients** must update route parameters from `:projectSlug` to `:project`  
⚠️ **Database migration** required before deployment  
⚠️ **Generated packages** (SDK/CLI) have new method signatures  

## Benefits
✅ Single source of truth for project identification  
✅ Cleaner API with one identifier instead of two  
✅ Simplified schema and security model  
✅ Better type safety throughout codebase  
✅ Improved DX with optional project parameters  

## Test Plan
- [x] All unit tests passing (544/544)
- [x] Security guard tests updated and passing
- [x] Service layer tests with new signatures
- [x] Generator output verified
- [ ] Migration tested on staging database
- [ ] Integration tests with generated SDK/CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)