### PR TITLE
Add Claude Code integration for intelligent PR generation

### DIFF
--- a/.github/workflows/multi-repo-publish.yml
+++ b/.github/workflows/multi-repo-publish.yml
@@ -161,12 +161,14 @@ jobs:
             echo "❌ Claude Code failed to generate SDK changelog"
             exit 1
           fi
-          echo "title<<EOF" >> $GITHUB_OUTPUT
+          # Use random delimiter to avoid conflicts
+          delimiter="$(openssl rand -hex 16)"
+          echo "title<<${delimiter}" >> $GITHUB_OUTPUT
           cat /tmp/sdk-pr-title.txt >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "${delimiter}" >> $GITHUB_OUTPUT
+          echo "body<<${delimiter}" >> $GITHUB_OUTPUT
           cat /tmp/sdk-pr-body.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "${delimiter}" >> $GITHUB_OUTPUT
 
       - name: Generate CLI Changelog
         if: ${{ inputs.publish_cli }}
@@ -191,12 +193,13 @@ jobs:
             echo "❌ Claude Code failed to generate CLI changelog"
             exit 1
           fi
-          echo "title<<EOF" >> $GITHUB_OUTPUT
+          delimiter="$(openssl rand -hex 16)"
+          echo "title<<${delimiter}" >> $GITHUB_OUTPUT
           cat /tmp/cli-pr-title.txt >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "${delimiter}" >> $GITHUB_OUTPUT
+          echo "body<<${delimiter}" >> $GITHUB_OUTPUT
           cat /tmp/cli-pr-body.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "${delimiter}" >> $GITHUB_OUTPUT
 
       - name: Generate n8n Changelog
         if: ${{ inputs.publish_n8n }}
@@ -221,12 +224,13 @@ jobs:
             echo "❌ Claude Code failed to generate n8n changelog"
             exit 1
           fi
-          echo "title<<EOF" >> $GITHUB_OUTPUT
+          delimiter="$(openssl rand -hex 16)"
+          echo "title<<${delimiter}" >> $GITHUB_OUTPUT
           cat /tmp/n8n-pr-title.txt >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "${delimiter}" >> $GITHUB_OUTPUT
+          echo "body<<${delimiter}" >> $GITHUB_OUTPUT
           cat /tmp/n8n-pr-body.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "${delimiter}" >> $GITHUB_OUTPUT
 
       - name: Create SDK Branch and PR
         if: ${{ inputs.publish_sdk }}


### PR DESCRIPTION
## 🚀 Claude Code Integration for Automated Changelog Generation

This PR implements intelligent PR generation using `anthropics/claude-code-base-action@beta` to automatically analyze code changes and create contextual PR descriptions when publishing SDK, CLI, and n8n packages.

### ✨ What's New

**Claude Code Integration:**
- Analyzes git diffs between published and generated packages
- Generates PR titles and detailed changelogs automatically
- No hallucination - only documents real code changes
- 5-minute timeout per package with fail-fast on errors

**Individual Package Versioning:**
- SDK, CLI, and n8n now track independent versions
- Each package syncs with its npm registry version
- CLI automatically updates its SDK dependency to match

**Configuration Externalization:**
- All repository names moved to GitHub variables
- Uses: `SDK_REPO`, `CLI_REPO`, `N8N_REPO`, `GIT_USER_EMAIL`, `GIT_USER_NAME`

### 📋 Changes

**New Files:**
- `.github/prompts/sdk-changelog.md` - SDK changelog generation instructions
- `.github/prompts/cli-changelog.md` - CLI changelog generation instructions  
- `.github/prompts/n8n-changelog.md` - n8n changelog generation instructions

**Modified:**
- `.github/workflows/multi-repo-publish.yml` - Complete refactor with Claude Code integration

### 🔧 Technical Details

**Workflow Architecture:**
1. Generate packages from backend contracts
2. Bump versions individually per package
3. Clone target repos and stage new files
4. Run Claude Code to analyze diffs and generate PR content
5. Extract titles and bodies from Claude output
6. Create PRs with intelligent, context-aware descriptions

**Key Features:**
- Repository setup before Claude Code execution enables `git diff --staged`
- Sequential echo commands for GitHub Actions multiline output compatibility
- Validation of Claude output files with clear error messages
- Reuse of cloned repos for efficiency
- Individual version tracking in GitHub outputs

### 🐛 Fixes Applied

- Fixed GitHub Actions multiline output syntax (heredoc delimiter issue)
- Changed from grouped heredoc to sequential echo commands

### 🎯 Testing

Ready to test via workflow_dispatch at: **Actions → Multi-Repo Package Publishing**

---

🤖 Ready for review and end-to-end testing