### PR TITLE
fix: copy .github directory to package repos

### DIFF
--- a/.github/workflows/multi-repo-publish.yml
+++ b/.github/workflows/multi-repo-publish.yml
@@ -101,8 +101,8 @@ jobs:
             echo "📦 Setting up SDK repo for analysis..."
             git clone https://x-access-token:$GITHUB_TOKEN@github.com/${{ vars.SDK_REPO }}.git sdk-repo
             cd sdk-repo
-            find . -maxdepth 1 -not -name '.git' -not -name '.github' -not -name '.' -not -name '..' -exec rm -rf {} \;
-            cp -r $GITHUB_WORKSPACE/generated/sdk/* .
+            find . -maxdepth 1 -not -name '.git' -not -name '.' -not -name '..' -exec rm -rf {} \;
+            cp -r $GITHUB_WORKSPACE/generated/sdk/. .
             git add .
             cd ..
           fi
@@ -111,8 +111,8 @@ jobs:
             echo "🖥️ Setting up CLI repo for analysis..."
             git clone https://x-access-token:$GITHUB_TOKEN@github.com/${{ vars.CLI_REPO }}.git cli-repo
             cd cli-repo
-            find . -maxdepth 1 -not -name '.git' -not -name '.github' -not -name '.' -not -name '..' -exec rm -rf {} \;
-            cp -r $GITHUB_WORKSPACE/generated/cli/* .
+            find . -maxdepth 1 -not -name '.git' -not -name '.' -not -name '..' -exec rm -rf {} \;
+            cp -r $GITHUB_WORKSPACE/generated/cli/. .
             git add .
             cd ..
           fi
@@ -121,8 +121,8 @@ jobs:
             echo "🎨 Setting up n8n repo for analysis..."
             git clone https://x-access-token:$GITHUB_TOKEN@github.com/${{ vars.N8N_REPO }}.git n8n-repo
             cd n8n-repo
-            find . -maxdepth 1 -not -name '.git' -not -name '.github' -not -name '.' -not -name '..' -exec rm -rf {} \;
-            cp -r $GITHUB_WORKSPACE/generated/n8n/* .
+            find . -maxdepth 1 -not -name '.git' -not -name '.' -not -name '..' -exec rm -rf {} \;
+            cp -r $GITHUB_WORKSPACE/generated/n8n/. .
             git add .
             cd ..
           fi


### PR DESCRIPTION
## Summary

Fixes the multi-repo-publish workflow to properly copy `.github/workflows` directory to package repositories.

### 🐛 Problem

The generated packages have `.github/workflows/publish.yml` in the backend repo, but they weren't being copied to the package repos (SDK, CLI, n8n).

**Root Cause**: Using `cp -r generated/sdk/*` - the glob (`*`) doesn't match hidden files/directories that start with `.`

### ✅ Solution

```bash
# Before (misses .github)
cp -r $GITHUB_WORKSPACE/generated/sdk/* .

# After (copies everything including .github)
cp -r $GITHUB_WORKSPACE/generated/sdk/. .
```

Also removed unnecessary `.github` exclusion from the `find` cleanup command since we want to overwrite it.

### 🔧 Changes

- SDK: `cp -r generated/sdk/. .` (includes `.github/`)
- CLI: `cp -r generated/cli/. .` (includes `.github/`)  
- n8n: `cp -r generated/n8n/. .` (includes `.github/`)
- Remove `-not -name '.github'` from find commands

### ✅ Result

Package repositories will now have:
```
.github/
└── workflows/
    └── publish.yml  # Auto-publishes to npm on PR merge
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)