### PR TITLE
fix: workflow improvements for changelog generation and package publishing

### DIFF
--- a/.github/workflows/multi-repo-publish.yml
+++ b/.github/workflows/multi-repo-publish.yml
@@ -134,7 +134,7 @@ jobs:
         uses: anthropics/claude-code-base-action@beta
         with:
           prompt_file: .github/prompts/sdk-changelog.md
-          allowed_tools: "Bash(git:*),Read,Write,Glob,Grep"
+          allowed_tools: "Bash(git:*),Bash(cd:*),Read(*),Write(/tmp/*),Glob,Grep"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             VERSION=${{ steps.versions.outputs.sdk_version }}
@@ -171,7 +171,7 @@ jobs:
         uses: anthropics/claude-code-base-action@beta
         with:
           prompt_file: .github/prompts/cli-changelog.md
-          allowed_tools: "Bash(git:*),Read,Write,Glob,Grep"
+          allowed_tools: "Bash(git:*),Bash(cd:*),Read(*),Write(/tmp/*),Glob,Grep"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             VERSION=${{ steps.versions.outputs.cli_version }}
@@ -208,7 +208,7 @@ jobs:
         uses: anthropics/claude-code-base-action@beta
         with:
           prompt_file: .github/prompts/n8n-changelog.md
-          allowed_tools: "Bash(git:*),Read,Write,Glob,Grep"
+          allowed_tools: "Bash(git:*),Bash(cd:*),Read(*),Write(/tmp/*),Glob,Grep"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             VERSION=${{ steps.versions.outputs.n8n_version }}

--- a/tools/generators/templates/cli/.github/workflows/publish.yml
+++ b/tools/generators/templates/cli/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish CLI to npm
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:
@@ -24,7 +21,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build package
         run: npm run build

--- a/tools/generators/templates/n8n/.github/workflows/publish.yml
+++ b/tools/generators/templates/n8n/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish n8n Node to npm
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:
@@ -24,7 +21,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build package
         run: npm run build

--- a/tools/generators/templates/sdk/.github/workflows/publish.yml
+++ b/tools/generators/templates/sdk/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish SDK to npm
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:
@@ -24,7 +21,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build package
         run: npm run build


### PR DESCRIPTION
## Summary

Fixes multiple workflow issues preventing successful changelog generation and package publishing.

### 🔧 Fix 1: Claude Code Permissions

**Problem**: Changelog generation was failing with permission errors:
```
This Bash command contains multiple operations. The following part requires approval: cd directory
```

**Solution**: Update `allowed_tools` for all changelog steps:

```yaml
# Before
allowed_tools: "Bash(git:*),Read,Write,Glob,Grep"

# After
allowed_tools: "Bash(git:*),Bash(cd:*),Read(*),Write(/tmp/*),Glob,Grep"
```

**Changes**:
- ✅ Add `Bash(cd:*)` - Allows `cd directory && git diff --staged` commands
- ✅ Expand `Read` to `Read(*)` - Allows reading any file
- ✅ Restrict `Write` to `Write(/tmp/*)` - Security: only /tmp writes allowed

### 🔧 Fix 2: Package Workflow Auto-Triggers

**Problem**: Package repos (SDK, CLI, n8n) would auto-publish on every PR merge to main

**Solution**: Change workflows to manual-only:

```yaml
# Before
on:
  push:
    branches: [main]
  workflow_dispatch:

# After
on:
  workflow_dispatch:
```

### 🔧 Fix 3: npm ci Failures

**Problem**: Package workflows failing with:
```
npm ci can only install with an existing package-lock.json
```

**Solution**: Use `npm install` instead:

```yaml
# Before
- name: Install dependencies
  run: npm ci

# After  
- name: Install dependencies
  run: npm install
```

Generated packages don't include `package-lock.json`, so `npm ci` cannot be used.

### ✅ Benefits

- **Claude Code changelogs work** - Can analyze git diffs and generate PRs
- **No accidental publishes** - Manual workflow trigger only
- **Package builds succeed** - npm install works without lockfile
- **Better security** - Restricted write permissions to /tmp only

🤖 Generated with [Claude Code](https://claude.com/claude-code)