### PR TITLE
refactor: make changelog prompts flexible and change-focused

### DIFF
--- a/.github/prompts/cli-changelog.md
+++ b/.github/prompts/cli-changelog.md
@@ -1,139 +1,96 @@
 # CLI Changelog Generation
 
-You are generating a PR description for the **@gatekit/cli** package update.
+Generate a PR description for the **@gatekit/cli** package based on actual code changes.
 
 ## Your Task
 
-1. **Compare current CLI repo with new generated CLI**:
-
-   The CLI repo has been cloned to `$GITHUB_WORKSPACE/cli-repo/` and new files copied from `generated/cli/`.
+1. **Analyze the git diff** to see what actually changed:
 
    ```bash
    cd $GITHUB_WORKSPACE/cli-repo
    git diff --staged
    ```
 
-   This shows the differences between the old CLI (in the repo) and new CLI (just copied).
+2. **Understand the changes** - Look for:
+   - New commands
+   - Updated dependencies
+   - Command structure changes
+   - Flag/option changes
+   - Breaking changes
 
-2. **Read contract metadata**:
+3. **Write concise output files**:
+   - `/tmp/cli-pr-title.txt` - One line title (no emojis)
+   - `/tmp/cli-pr-body.md` - Markdown PR description
 
-   ```bash
-   cat $GITHUB_WORKSPACE/generated/contracts/contracts.json
-   ```
+## Output Guidelines
 
-3. **Understand what changed**:
-   - New CLI commands added
-   - Changed command patterns
-   - New flags/options
-   - Permission system updates
-   - Breaking changes in command structure
+**Title** (`/tmp/cli-pr-title.txt`):
 
-4. **Generate PR title and description**:
-   - Write PR title to `/tmp/cli-pr-title.txt` (single line, no markdown)
-   - Write PR body to `/tmp/cli-pr-body.md` (full markdown description)
+- One line, descriptive, no emojis
+- Focus on the MAIN change
+- Examples: "Update CLI dependencies", "Add message commands", "Fix config handling"
 
-## Output Format
+**Body** (`/tmp/cli-pr-body.md`):
 
-**File 1: `/tmp/cli-pr-title.txt`** (Single line, no emojis, descriptive)
+- Start with brief summary
+- List only ACTUAL changes from git diff
+- Include version info: `**Version**: v{VERSION}`
+- Link to source: `**Source**: [{COMMIT_SHA}](https://github.com/filipexyz/gatekit/commit/{COMMIT_SHA})`
+- Keep it concise and direct
 
-```
-Update CLI with [brief description of main changes]
-```
-
-Examples:
-
-- "Update CLI with new message commands"
-- "Update CLI with breaking changes to platform commands"
-- "Update CLI with permission-aware command system"
-
-**File 2: `/tmp/cli-pr-body.md`** (Full markdown description)
-
-Write a GitHub PR description to `/tmp/cli-pr-body.md` with this structure:
+## Structure (adapt as needed)
 
 ````markdown
-## 🚀 Auto-generated CLI Update
+## Summary
+
+[1-2 sentence description of what changed]
 
 **Version**: v{VERSION}
-**Source**: [{COMMIT_SHA}](https://github.com/GateKit/backend/commit/{COMMIT_SHA})
+**Source**: [{COMMIT_SHA}](https://github.com/filipexyz/gatekit/commit/{COMMIT_SHA})
 
-### 📋 Changes
+### Changes
 
-#### ✨ New Commands
+[List actual changes - be specific and direct]
 
-- `gatekit command-name` - Description
-- List all new commands added
+- If new commands: list them with brief description
+- If dependency updates: list old→new versions
+- If breaking changes: explain clearly
+- If bug fixes: mention what was fixed
 
-#### 🔧 Improvements
-
-- Enhanced pattern system
-- Better error messages
-- Permission-aware command discovery
-
-#### ⚠️ Breaking Changes
-
-(Only if applicable)
-
-- List breaking changes in command structure
-- Explain migration path for users
-
-#### 🎯 Revolutionary Pattern System
-
-Show examples of new command patterns:
+### Usage Examples (only if new features)
 
 ```bash
-# Simple targets
-gatekit messages send --target "platformId:user:123" --text "Message"
-
-# Multiple targets
-gatekit messages send --targets "p1:user:123,p2:channel:456" --text "Broadcast"
-
-# New functionality
-gatekit new-command --option "value"
+# Show actual new commands if applicable
+gatekit new-command --option value
 ```
 ````
 
-#### 📊 Technical Details
+### Migration (only if breaking changes)
 
-- X new commands generated
-- Y contracts covered
-- Z permission scopes supported
-
-### 💡 Usage Examples
-
-```bash
-# Example 1: New feature
-gatekit example-command --flag value
-
-# Example 2: Updated pattern
-gatekit updated-command --new-option
-```
-
-### 🎯 Testing Checklist
-
-- [ ] All commands compile
-- [ ] CLI help text accurate
-- [ ] Permission discovery working
-- [ ] Breaking changes documented
-
----
-
-🤖 Generated with Claude Code - Ready for review and merge
+[Instructions if needed]
 
 ```
 
 ## Important Rules
 
-- Focus ONLY on CLI changes (ignore SDK/n8n)
-- Emphasize command-line usability
-- Show practical bash examples
-- Highlight pattern system improvements
-- No hallucination - only document real changes
-- Write PR title to `/tmp/cli-pr-title.txt` (one line, no emoji)
-- Write the complete PR body to `/tmp/cli-pr-body.md`
+✅ **DO**:
+- Be flexible - adapt structure to fit actual changes
+- Focus on what matters - skip sections if not applicable
+- Be direct and concise
+- Use actual command names from git diff
+- Include only relevant information
+- Show real command examples if adding new features
 
-## Environment Variables Available
+❌ **DON'T**:
+- Add sections that don't apply
+- Include placeholder text like "X commands generated" if not relevant
+- Add generic "improvements" that aren't real
+- Use rigid template when simple is better
+- Hallucinate commands
 
-- `VERSION`: Package version
-- `COMMIT_SHA`: Git commit hash
-- `COMMIT_MSG`: Original commit message
+## Environment Variables
+
+- `VERSION` - Package version
+- `COMMIT_SHA` - Commit hash
+- `COMMIT_MSG` - Commit message
 ```

--- a/.github/prompts/n8n-changelog.md
+++ b/.github/prompts/n8n-changelog.md
@@ -1,127 +1,93 @@
-# n8n Node Changelog Generation
+# n8n Changelog Generation
 
-You are generating a PR description for the **n8n-nodes-gatekit** package update.
+Generate a PR description for the **n8n-nodes-gatekit** package based on actual code changes.
 
 ## Your Task
 
-1. **Compare current n8n repo with new generated n8n**:
-
-   The n8n repo has been cloned to `$GITHUB_WORKSPACE/n8n-repo/` and new files copied from `generated/n8n/`.
+1. **Analyze the git diff** to see what actually changed:
 
    ```bash
    cd $GITHUB_WORKSPACE/n8n-repo
    git diff --staged
    ```
 
-   This shows the differences between the old n8n nodes (in the repo) and new n8n nodes (just copied).
+2. **Understand the changes** - Look for:
+   - New operations
+   - Updated dependencies
+   - Node parameter changes
+   - Workflow capabilities
+   - Breaking changes
 
-2. **Read contract metadata**:
+3. **Write concise output files**:
+   - `/tmp/n8n-pr-title.txt` - One line title (no emojis)
+   - `/tmp/n8n-pr-body.md` - Markdown PR description
 
-   ```bash
-   cat $GITHUB_WORKSPACE/generated/contracts/contracts.json
-   ```
+## Output Guidelines
 
-3. **Understand what changed**:
-   - New n8n operations added
-   - Changed node parameters
-   - New workflow capabilities
-   - Visual UI improvements
-   - Breaking changes in node structure
+**Title** (`/tmp/n8n-pr-title.txt`):
 
-4. **Generate PR title and description**:
-   - Write PR title to `/tmp/n8n-pr-title.txt` (single line, no markdown)
-   - Write PR body to `/tmp/n8n-pr-body.md` (full markdown description)
+- One line, descriptive, no emojis
+- Focus on the MAIN change
+- Examples: "Update n8n dependencies", "Add webhook operations", "Fix node parameters"
 
-## Output Format
+**Body** (`/tmp/n8n-pr-body.md`):
 
-**File 1: `/tmp/n8n-pr-title.txt`** (Single line, no emojis, descriptive)
+- Start with brief summary
+- List only ACTUAL changes from git diff
+- Include version info: `**Version**: v{VERSION}`
+- Link to source: `**Source**: [{COMMIT_SHA}](https://github.com/filipexyz/gatekit/commit/{COMMIT_SHA})`
+- Keep it concise and direct
 
-```
-Update n8n nodes with [brief description of main changes]
-```
-
-Examples:
-
-- "Update n8n nodes with new messaging operations"
-- "Update n8n nodes with webhook support"
-- "Update n8n nodes with platform management operations"
-
-**File 2: `/tmp/n8n-pr-body.md`** (Full markdown description)
-
-Write a GitHub PR description to `/tmp/n8n-pr-body.md` with this structure:
+## Structure (adapt as needed)
 
 ```markdown
-## 🚀 Auto-generated n8n Nodes Update
+## Summary
+
+[1-2 sentence description of what changed]
 
 **Version**: v{VERSION}
-**Source**: [{COMMIT_SHA}](https://github.com/GateKit/backend/commit/{COMMIT_SHA})
+**Source**: [{COMMIT_SHA}](https://github.com/filipexyz/gatekit/commit/{COMMIT_SHA})
 
-### 📋 Changes
+### Changes
 
-#### ✨ New Operations
+[List actual changes - be specific and direct]
 
-- **Operation Name** - Description
-- List all new n8n operations added
+- If new operations: list them with brief description
+- If dependency updates: list old→new versions
+- If breaking changes: explain clearly
+- If bug fixes: mention what was fixed
 
-#### 🔧 Improvements
+### Workflow Impact (only if new features)
 
-- Enhanced visual workflow capabilities
-- Better parameter validation
-- Improved error handling in nodes
+[Describe how new features enable workflows]
 
-#### ⚠️ Breaking Changes
+### Migration (only if breaking changes)
 
-(Only if applicable)
-
-- List breaking changes in node structure
-- Migration guide for existing workflows
-
-#### 🎨 n8n Community Impact
-
-- 🎯 **300k+ n8n users** benefit from GateKit automation
-- 🔧 **Visual workflows** for messaging platforms
-- 🚀 **Drag-and-drop** platform management
-
-#### 📊 Technical Details
-
-- X new operations generated
-- Y contracts converted to nodes
-- Z workflow capabilities added
-
-### 💡 Workflow Examples
-
-Describe new workflow possibilities:
-```
-
-1. [Trigger] → [GateKit: New Operation] → [Action]
-2. [Schedule] → [GateKit: Send Message] → [Notification]
-
-```
-
-### 🎯 Testing Checklist
-
-- [ ] n8n package compiles
-- [ ] Node descriptions accurate
-- [ ] Parameter validation working
-- [ ] Credentials flow functional
-
----
-
-🤖 Generated with Claude Code - Ready for review and merge
+[Instructions if needed]
 ```
 
 ## Important Rules
 
-- Focus ONLY on n8n node changes (ignore SDK/CLI)
-- Emphasize visual workflow capabilities
-- Highlight community impact (300k+ users)
-- Use n8n terminology (operations, nodes, workflows)
-- No hallucination - only document real changes
-- Write PR title to `/tmp/n8n-pr-title.txt` (one line, no emoji)
-- Write the complete PR body to `/tmp/n8n-pr-body.md`
+✅ **DO**:
 
-## Environment Variables Available
+- Be flexible - adapt structure to fit actual changes
+- Focus on what matters - skip sections if not applicable
+- Be direct and concise
+- Use actual operation names from git diff
+- Include only relevant information
+- Mention workflow impact if adding new features
 
-- `VERSION`: Package version
-- `COMMIT_SHA`: Git commit hash
-- `COMMIT_MSG`: Original commit message
+❌ **DON'T**:
+
+- Add sections that don't apply
+- Include placeholder text like "X operations generated" if not relevant
+- Add generic "improvements" that aren't real
+- Use rigid template when simple is better
+- Hallucinate operations
+- Always mention "300k+ users" (only if relevant context)
+
+## Environment Variables
+
+- `VERSION` - Package version
+- `COMMIT_SHA` - Commit hash
+- `COMMIT_MSG` - Commit message

--- a/.github/prompts/sdk-changelog.md
+++ b/.github/prompts/sdk-changelog.md
@@ -1,125 +1,87 @@
 # SDK Changelog Generation
 
-You are generating a PR description for the **@gatekit/sdk** package update.
+Generate a PR description for the **@gatekit/sdk** package based on actual code changes.
 
 ## Your Task
 
-1. **Compare current SDK repo with new generated SDK**:
-
-   The SDK repo has been cloned to `$GITHUB_WORKSPACE/sdk-repo/` and new files copied from `generated/sdk/`.
+1. **Analyze the git diff** to see what actually changed:
 
    ```bash
    cd $GITHUB_WORKSPACE/sdk-repo
    git diff --staged
    ```
 
-   This shows the differences between the old SDK (in the repo) and new SDK (just copied).
+2. **Understand the changes** - Look for:
+   - New methods/endpoints
+   - Updated dependencies
+   - Type changes
+   - Configuration updates
+   - Breaking changes
 
-2. **Read contract metadata**:
+3. **Write concise output files**:
+   - `/tmp/sdk-pr-title.txt` - One line title (no emojis)
+   - `/tmp/sdk-pr-body.md` - Markdown PR description
 
-   ```bash
-   cat $GITHUB_WORKSPACE/generated/contracts/contracts.json
-   ```
+## Output Guidelines
 
-3. **Understand what changed**:
-   - New API endpoints added to SDK
-   - Changed method signatures
-   - New types extracted
-   - Breaking changes in contracts
-   - Removed functionality
+**Title** (`/tmp/sdk-pr-title.txt`):
 
-4. **Generate PR title and description**:
-   - Write PR title to `/tmp/sdk-pr-title.txt` (single line, no markdown)
-   - Write PR body to `/tmp/sdk-pr-body.md` (full markdown description)
+- One line, descriptive, no emojis
+- Focus on the MAIN change
+- Examples: "Update SDK dependencies", "Add webhook support", "Fix message delivery"
 
-## Output Format
+**Body** (`/tmp/sdk-pr-body.md`):
 
-**File 1: `/tmp/sdk-pr-title.txt`** (Single line, no emojis, descriptive)
+- Start with brief summary
+- List only ACTUAL changes from git diff
+- Include version info: `**Version**: v{VERSION}`
+- Link to source: `**Source**: [{COMMIT_SHA}](https://github.com/filipexyz/gatekit/commit/{COMMIT_SHA})`
+- Keep it concise and direct
 
-```
-Update SDK with [brief description of main changes]
-```
+## Structure (adapt as needed)
 
-Examples:
+```markdown
+## Summary
 
-- "Update SDK with webhook notification support"
-- "Update SDK with breaking changes to message API"
-- "Update SDK with new platform capabilities"
-
-**File 2: `/tmp/sdk-pr-body.md`** (Full markdown description)
-
-Write a GitHub PR description to `/tmp/sdk-pr-body.md` with this structure:
-
-````markdown
-## 🚀 Auto-generated SDK Update
+[1-2 sentence description of what changed]
 
 **Version**: v{VERSION}
-**Source**: [{COMMIT_SHA}](https://github.com/GateKit/backend/commit/{COMMIT_SHA})
+**Source**: [{COMMIT_SHA}](https://github.com/filipexyz/gatekit/commit/{COMMIT_SHA})
 
-### 📋 Changes
+### Changes
 
-#### ✨ New Features
+[List actual changes - be specific and direct]
 
-- List new endpoints/methods added
-- Highlight new capabilities
+- If new features: describe them
+- If dependency updates: list old→new versions
+- If breaking changes: explain clearly
+- If bug fixes: mention what was fixed
 
-#### 🔧 Improvements
+### Migration (only if breaking changes)
 
-- Enhanced type safety
-- Better error handling
-- Performance improvements
-
-#### ⚠️ Breaking Changes
-
-(Only if applicable)
-
-- List breaking changes
-- Explain migration path
-
-#### 📊 Technical Details
-
-- X contracts extracted
-- Y types auto-discovered
-- Z new methods generated
-
-### 💡 Usage Examples
-
-(Provide 1-2 code examples showing new features)
-
-```typescript
-// Example of new functionality
-const gk = new GateKit({ apiKey: 'your-key' });
-await gk.newFeature.doSomething();
-```
-````
-
-### 🎯 Testing Checklist
-
-- [ ] All TypeScript types compile
-- [ ] SDK integration tests pass
-- [ ] No breaking changes without migration guide
-- [ ] Documentation updated
-
----
-
-🤖 Generated with Claude Code - Ready for review and merge
-
+[Instructions if needed]
 ```
 
 ## Important Rules
 
-- Focus ONLY on SDK changes (ignore CLI/n8n)
-- Be concise but thorough
-- Highlight breaking changes prominently
-- Use actual examples from the code
-- No hallucination - only document real changes
-- Use emojis sparingly and professionally
-- Write PR title to `/tmp/sdk-pr-title.txt` (one line, no emoji)
-- Write the complete PR body to `/tmp/sdk-pr-body.md`
+✅ **DO**:
 
-## Environment Variables Available
+- Be flexible - adapt structure to fit actual changes
+- Focus on what matters - skip sections if not applicable
+- Be direct and concise
+- Use actual code/version numbers from git diff
+- Include only relevant information
 
-- `VERSION`: Package version
-- `COMMIT_SHA`: Git commit hash
-- `COMMIT_MSG`: Original commit message
-```
+❌ **DON'T**:
+
+- Add sections that don't apply
+- Include placeholder text like "X contracts extracted" if not relevant
+- Add generic "improvements" that aren't real
+- Use rigid template when simple is better
+- Hallucinate features
+
+## Environment Variables
+
+- `VERSION` - Package version
+- `COMMIT_SHA` - Commit hash
+- `COMMIT_MSG` - Commit message


### PR DESCRIPTION
## Summary

Rewrote all Claude Code changelog generation prompts to be flexible and focus on actual git diff changes instead of following rigid templates.

### Changes

**All three prompts (SDK, CLI, n8n) updated with:**

- Flexible structure that adapts to actual changes
- Clear DO/DON'T guidelines emphasizing flexibility
- Direct instructions to analyze git diff and list only real changes
- Removed rigid template sections that don't always apply
- Removed "Generated with Claude Code" footer
- Focus on concise, relevant information only

**Before**: Prompts encouraged following a strict template structure with sections that might not apply

**After**: Prompts emphasize adapting to fit actual changes and skipping irrelevant sections

### Files Modified

- `.github/prompts/sdk-changelog.md`
- `.github/prompts/cli-changelog.md`
- `.github/prompts/n8n-changelog.md`

Co-Authored-By: Claude <noreply@anthropic.com>