### PR TITLE
fix: add @types/node devDependency to CLI package

### DIFF
--- a/tools/generators/cli-generator.ts
+++ b/tools/generators/cli-generator.ts
@@ -505,8 +505,9 @@ export function handleError(error: any): void {
           commander: '^14.0.1',
           axios: '^1.12.2',
         },
-        peerDependencies: {
-          typescript: '>=5.0.0',
+        devDependencies: {
+          '@types/node': '^22.18.8',
+          typescript: '^5.9.3',
         },
         keywords: ['gatekit', 'cli', 'messaging', 'universal'],
         author: 'GateKit',


### PR DESCRIPTION
## Summary

CLI package was failing to build due to missing TypeScript type definitions for Node.js.

### Problem

Build errors in CLI package repo:
```
Error: Cannot find name 'require'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
Error: Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.
Error: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
Error: Cannot find module 'fs' or its corresponding type declarations.
Error: Cannot find module 'path' or its corresponding type declarations.
Error: Cannot find module 'os' or its corresponding type declarations.
```

### Solution

Added `@types/node` and `typescript` to CLI package's `devDependencies`:
- `@types/node: ^22.18.8` (matches backend version)
- `typescript: ^5.9.3` (explicit dev dependency)

### Files Modified

- `tools/generators/cli-generator.ts`

Co-Authored-By: Claude <noreply@anthropic.com>