### PR TITLE
fix: use environment variables properly in changelog prompts

### DIFF
--- a/.github/prompts/cli-changelog.md
+++ b/.github/prompts/cli-changelog.md
@@ -34,8 +34,8 @@ Generate a PR description for the **@gatekit/cli** package based on actual code 
 
 - Start with brief summary
 - List only ACTUAL changes from git diff
-- Include version info: `**Version**: v{VERSION}`
-- Link to source: `**Source**: [{COMMIT_SHA}](https://github.com/filipexyz/gatekit/commit/{COMMIT_SHA})`
+- Include version info using $VERSION: `**Version**: v$VERSION`
+- Link to source backend: `**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)`
 - Keep it concise and direct
 
 ## Structure (adapt as needed)
@@ -45,8 +45,8 @@ Generate a PR description for the **@gatekit/cli** package based on actual code 
 
 [1-2 sentence description of what changed]
 
-**Version**: v{VERSION}
-**Source**: [{COMMIT_SHA}](https://github.com/filipexyz/gatekit/commit/{COMMIT_SHA})
+**Version**: v$VERSION
+**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)
 
 ### Changes
 
@@ -90,7 +90,12 @@ gatekit new-command --option value
 
 ## Environment Variables
 
-- `VERSION` - Package version
-- `COMMIT_SHA` - Commit hash
-- `COMMIT_MSG` - Commit message
+Available as shell environment variables (access with `$VARIABLE_NAME`):
+
+- `$VERSION` - Package version (e.g., "1.2.1")
+- `$COMMIT_SHA` - Commit hash (e.g., "a1b2c3d")
+- `$COMMIT_MSG` - Commit message
+- `$GITHUB_WORKSPACE` - Workspace directory
+
+**IMPORTANT**: Use these actual values in your output, not placeholder text!
 ```

--- a/.github/prompts/n8n-changelog.md
+++ b/.github/prompts/n8n-changelog.md
@@ -34,8 +34,8 @@ Generate a PR description for the **n8n-nodes-gatekit** package based on actual 
 
 - Start with brief summary
 - List only ACTUAL changes from git diff
-- Include version info: `**Version**: v{VERSION}`
-- Link to source: `**Source**: [{COMMIT_SHA}](https://github.com/filipexyz/gatekit/commit/{COMMIT_SHA})`
+- Include version info using $VERSION: `**Version**: v$VERSION`
+- Link to source backend: `**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)`
 - Keep it concise and direct
 
 ## Structure (adapt as needed)
@@ -45,8 +45,8 @@ Generate a PR description for the **n8n-nodes-gatekit** package based on actual 
 
 [1-2 sentence description of what changed]
 
-**Version**: v{VERSION}
-**Source**: [{COMMIT_SHA}](https://github.com/filipexyz/gatekit/commit/{COMMIT_SHA})
+**Version**: v$VERSION
+**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)
 
 ### Changes
 
@@ -88,6 +88,11 @@ Generate a PR description for the **n8n-nodes-gatekit** package based on actual 
 
 ## Environment Variables
 
-- `VERSION` - Package version
-- `COMMIT_SHA` - Commit hash
-- `COMMIT_MSG` - Commit message
+Available as shell environment variables (access with `$VARIABLE_NAME`):
+
+- `$VERSION` - Package version (e.g., "1.2.1")
+- `$COMMIT_SHA` - Commit hash (e.g., "a1b2c3d")
+- `$COMMIT_MSG` - Commit message
+- `$GITHUB_WORKSPACE` - Workspace directory
+
+**IMPORTANT**: Use these actual values in your output, not placeholder text!

--- a/.github/prompts/sdk-changelog.md
+++ b/.github/prompts/sdk-changelog.md
@@ -34,8 +34,8 @@ Generate a PR description for the **@gatekit/sdk** package based on actual code 
 
 - Start with brief summary
 - List only ACTUAL changes from git diff
-- Include version info: `**Version**: v{VERSION}`
-- Link to source: `**Source**: [{COMMIT_SHA}](https://github.com/filipexyz/gatekit/commit/{COMMIT_SHA})`
+- Include version info using $VERSION: `**Version**: v$VERSION`
+- Link to source backend: `**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)`
 - Keep it concise and direct
 
 ## Structure (adapt as needed)
@@ -45,8 +45,8 @@ Generate a PR description for the **@gatekit/sdk** package based on actual code 
 
 [1-2 sentence description of what changed]
 
-**Version**: v{VERSION}
-**Source**: [{COMMIT_SHA}](https://github.com/filipexyz/gatekit/commit/{COMMIT_SHA})
+**Version**: v$VERSION
+**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)
 
 ### Changes
 
@@ -82,6 +82,11 @@ Generate a PR description for the **@gatekit/sdk** package based on actual code 
 
 ## Environment Variables
 
-- `VERSION` - Package version
-- `COMMIT_SHA` - Commit hash
-- `COMMIT_MSG` - Commit message
+Available as shell environment variables (access with `$VARIABLE_NAME`):
+
+- `$VERSION` - Package version (e.g., "1.2.1")
+- `$COMMIT_SHA` - Commit hash (e.g., "a1b2c3d")
+- `$COMMIT_MSG` - Commit message
+- `$GITHUB_WORKSPACE` - Workspace directory
+
+**IMPORTANT**: Use these actual values in your output, not placeholder text!


### PR DESCRIPTION
## Summary

Claude Code was generating PR descriptions with empty version and source values because the prompts used placeholder syntax instead of actual environment variables.

### Problem

Generated changelog showed:
```
**Version**: v
**Source**: 
```

Root causes:
1. Prompts used `{VERSION}` placeholder syntax instead of `$VERSION` shell variable
2. Using `$COMMIT_SHA` for multi-commit PRs only shows latest commit
3. No explicit instruction to substitute actual values

### Solution

**Environment Variable Syntax:**
- Changed `{VERSION}` → `$VERSION` 
- Changed `{COMMIT_SHA}` → removed (PRs may have multiple commits)
- Added explicit instruction: "Use these actual values in your output, not placeholder text!"

**Source Links:**
- Removed commit-specific links (doesn't work for multi-commit PRs)
- Now links to backend repo: `[GateKit Backend](https://github.com/filipexyz/gatekit)`

**Enhanced Documentation:**
- Clarified environment variables are shell variables accessed with `$`
- Added examples: `$VERSION` (e.g., "1.2.1")
- Emphasized using actual values vs placeholders

### Files Modified

- `.github/prompts/sdk-changelog.md`
- `.github/prompts/cli-changelog.md`
- `.github/prompts/n8n-changelog.md`

Co-Authored-By: Claude <noreply@anthropic.com>