### PR TITLE
fix: CLI uses 'latest' SDK version instead of backend version

### DIFF
--- a/tools/generators/cli-generator.ts
+++ b/tools/generators/cli-generator.ts
@@ -615,7 +615,7 @@ export function handleError(error: any): void {
           prepublishOnly: 'npm run build',
         },
         dependencies: {
-          '@gatekit/sdk': `^${packageJson.version}`,
+          '@gatekit/sdk': 'latest',
           commander: '^14.0.1',
           axios: '^1.12.2',
         },


### PR DESCRIPTION
## Summary

- CLI now uses `"@gatekit/sdk": "latest"` instead of version from backend package.json
- Solves chicken-and-egg problem when publishing CLI before SDK
- Allows CLI to be published even when matching SDK version doesn't exist in npm

## Problem

When publishing CLI v1.2.2, it references `@gatekit/sdk@^1.2.2` which doesn't exist in npm registry yet, causing:
```
npm error notarget No matching version found for @gatekit/sdk@^1.2.2
```

## Solution

Use `"latest"` tag instead of hardcoded version:
```json
"dependencies": {
  "@gatekit/sdk": "latest"
}
```

## Benefits

- CLI can be published independently
- Always uses latest stable SDK from npm
- No version coordination needed between SDK and CLI
- Works in CI without special handling

## Files Changed

- `tools/generators/cli-generator.ts` - Changed SDK dependency to "latest"

🤖 Co-Authored-By: Claude <noreply@anthropic.com>