### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@nestjs/axios": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
## Summary
- Minor version bump from 1.2.2 to 1.3.0
- Regenerated all packages (SDK, CLI, n8n, OpenAPI)
- All validations passing

## Changes
- Updated package.json version
- Regenerated contracts and all derived packages
- All generated packages compile successfully

Co-Authored-By: Claude <noreply@anthropic.com>