### PR TITLE
fix: remove hardcoded version check in CLI integration test

### DIFF
--- a/test/cli-integration.e2e-spec.ts
+++ b/test/cli-integration.e2e-spec.ts
@@ -46,7 +46,8 @@ describe('CLI Integration Tests (e2e)', () => {
         timeout: 5000,
       });
 
-      expect(stdout).toContain('1.2.2');
+      // CLI version should match any semantic version
+      expect(stdout).toMatch(/\d+\.\d+\.\d+/);
     }, 30000);
 
     it('should not have duplicate Commander.js options', async () => {


### PR DESCRIPTION
## Summary
- Removed hardcoded version check (1.2.2) from CLI integration test
- Changed to match any semantic version pattern instead

## Problem
The test was failing on every version bump because it expected a specific hardcoded version string.

## Solution
Test now validates that CLI returns a semantic version (e.g., `\d+\.\d+\.\d+`) instead of checking for a specific version number.

Co-Authored-By: Claude <noreply@anthropic.com>