### PR TITLE
fix: CLI array parsing for comma-separated values

### DIFF
--- a/tools/generators/cli-generator.ts
+++ b/tools/generators/cli-generator.ts
@@ -288,6 +288,9 @@ ${allOptions}
         if (option.type === 'object') {
           // Parse JSON strings for object types with try-catch
           return `      ${key}: options.${key} ? (() => { try { return JSON.parse(options.${key}); } catch (e) { throw new Error(\`Invalid JSON for --${key}: \${e instanceof Error ? e.message : String(e)}\`); } })() : undefined`;
+        } else if (option.type === 'array') {
+          // Split comma-separated values into array
+          return `      ${key}: options.${key} ? (typeof options.${key} === 'string' ? options.${key}.split(',').map((v: string) => v.trim()) : options.${key}) : undefined`;
         } else if (option.type === 'boolean') {
           // Convert string to boolean, preserve undefined when not provided
           return `      ${key}: options.${key} !== undefined ? (options.${key} === 'true' || options.${key} === true) : undefined`;


### PR DESCRIPTION
## Summary

Fixes CLI array parsing issue where comma-separated values were not properly converted to arrays.

## Problem

The CLI generator handled array parsing for platform-specific options but not for standard DTO options. This caused commands like:

```bash
gatekit webhooks create --events message.received,message.sent,message.failed
```

To fail validation because the `events` parameter was passed as a string instead of an array.

## Solution

Added array type handling in the `buildDtoObjectFromContract()` method of `cli-generator.ts`:

- Detects `array` type options
- Splits comma-separated strings into arrays
- Trims whitespace from each value
- Maintains backwards compatibility with existing functionality

## Changes

- **File**: `tools/generators/cli-generator.ts`
- **Lines**: Added 3 lines for array type parsing (lines 291-293)

## Testing

✅ **Manual Testing:**
```bash
# Test command now works correctly
gatekit webhooks create \
  --name "Test Webhook" \
  --url "https://example.com/webhook" \
  --events "message.received,message.sent,message.failed" \
  --json

# Result: events correctly parsed as array
{
  "events": ["message.received", "message.sent", "message.failed"]
}
```

✅ **No Breaking Changes:**
- Platform options array parsing unchanged
- Object, boolean, number, string types unchanged
- All existing CLI tests pass

## Impact

- Fixes webhook creation via CLI
- Fixes any other array-type DTO fields in future
- Improves CLI usability with comma-separated values

🤖 Generated with [Claude Code](https://claude.com/claude-code)