### PR TITLE
feat: add trigger node generation to n8n package

### DIFF
--- a/tools/generators/n8n-generator.ts
+++ b/tools/generators/n8n-generator.ts
@@ -8,6 +8,7 @@ import packageJson from '../../package.json';
 
 interface GeneratedN8N {
   nodeFile: string;
+  triggerNodeFile: string;
   credentialsFile: string;
   packageJson: string;
   gulpfile: string;
@@ -48,12 +49,269 @@ export class N8NGenerator {
   private generateN8NNode(contracts: ExtractedContract[]): GeneratedN8N {
     return {
       nodeFile: this.generateNodeFile(contracts),
+      triggerNodeFile: this.generateTriggerNodeFile(),
       credentialsFile: this.generateCredentialsFile(),
       packageJson: this.generatePackageJson(),
       gulpfile: this.generateGulpfile(),
       indexFile: this.generateIndexFile(),
       contracts,
     };
+  }
+
+  private generateTriggerNodeFile(): string {
+    return `import {
+  IHookFunctions,
+  IWebhookFunctions,
+  INodeType,
+  INodeTypeDescription,
+  IWebhookResponseData,
+} from 'n8n-workflow';
+
+export class GateKitTrigger implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: 'GateKit Trigger',
+    name: 'gateKitTrigger',
+    icon: 'file:gatekit.svg',
+    group: ['trigger'],
+    version: 1,
+    description: 'Triggers workflow when messages are received via GateKit',
+    defaults: {
+      name: 'GateKit Trigger',
+    },
+    inputs: [],
+    outputs: ['main'],
+    credentials: [
+      {
+        name: 'GateKitApi',
+        required: true,
+      },
+    ],
+    webhooks: [
+      {
+        name: 'default',
+        httpMethod: 'POST',
+        responseMode: 'onReceived',
+        path: 'webhook',
+      },
+    ],
+    properties: [
+      {
+        displayName: 'Project ID',
+        name: 'projectId',
+        type: 'string',
+        default: 'default',
+        required: true,
+        description: 'The GateKit project ID to monitor for messages',
+      },
+      {
+        displayName: 'Events',
+        name: 'events',
+        type: 'multiOptions',
+        options: [
+          {
+            name: 'Message Received',
+            value: 'message.received',
+            description: 'Trigger when a message is received',
+          },
+          {
+            name: 'Message Sent',
+            value: 'message.sent',
+            description: 'Trigger when a message is sent successfully',
+          },
+          {
+            name: 'Message Failed',
+            value: 'message.failed',
+            description: 'Trigger when a message fails to send',
+          },
+        ],
+        default: ['message.received'],
+        required: true,
+        description: 'The events to subscribe to',
+      },
+      {
+        displayName: 'Webhook Name',
+        name: 'webhookName',
+        type: 'string',
+        default: 'n8n Webhook',
+        description: 'Name to identify this webhook in GateKit dashboard',
+      },
+    ],
+  };
+
+  webhookMethods = {
+    default: {
+      async checkExists(this: IHookFunctions): Promise<boolean> {
+        const webhookData = this.getWorkflowStaticData('node');
+        const credentials = await this.getCredentials('GateKitApi');
+
+        if (webhookData.webhookId === undefined) {
+          return false;
+        }
+
+        const projectId = this.getNodeParameter('projectId') as string;
+        if (!projectId) {
+          throw new Error('Project ID is required');
+        }
+
+        const apiUrl = credentials.apiUrl as string;
+
+        try {
+          const response = await this.helpers.request({
+            method: 'GET',
+            url: \`\${apiUrl}/api/v1/projects/\${projectId}/webhooks/\${webhookData.webhookId}\`,
+            headers: {
+              'X-API-Key': credentials.apiKey as string,
+            },
+            json: true,
+          });
+
+          return !!response;
+        } catch (error: any) {
+          if (error.statusCode === 404 || error.response?.status === 404) {
+            delete webhookData.webhookId;
+            delete webhookData.webhookSecret;
+            delete webhookData.events;
+            return false;
+          }
+          throw error;
+        }
+      },
+
+      async create(this: IHookFunctions): Promise<boolean> {
+        const webhookUrl = this.getNodeWebhookUrl('default') as string;
+        const credentials = await this.getCredentials('GateKitApi');
+        const projectId = this.getNodeParameter('projectId') as string;
+        const events = this.getNodeParameter('events', []) as string[];
+        const webhookName = this.getNodeParameter('webhookName', 'n8n Webhook') as string;
+
+        if (!projectId) {
+          throw new Error('Project ID is required');
+        }
+
+        if (webhookUrl.includes('//localhost')) {
+          throw new Error(
+            'The Webhook cannot work on "localhost". Please setup n8n on a custom domain or start with "--tunnel"!'
+          );
+        }
+
+        const apiUrl = credentials.apiUrl as string;
+
+        try {
+          const response = await this.helpers.request({
+            method: 'POST',
+            url: \`\${apiUrl}/api/v1/projects/\${projectId}/webhooks\`,
+            headers: {
+              'X-API-Key': credentials.apiKey as string,
+              'Content-Type': 'application/json',
+            },
+            body: {
+              url: webhookUrl,
+              events: events,
+              name: webhookName,
+              // Let GateKit auto-generate a secure secret
+            },
+            json: true,
+          });
+
+          if (!response || !response.id) {
+            throw new Error('Invalid response from GateKit API: missing webhook ID');
+          }
+
+          const webhookData = this.getWorkflowStaticData('node');
+          webhookData.webhookId = response.id;
+          webhookData.webhookSecret = response.secret; // Store secret for HMAC validation
+          webhookData.events = events;
+
+          return true;
+        } catch (error: any) {
+          throw new Error(\`Failed to create GateKit webhook: \${error.message || String(error)}\`);
+        }
+      },
+
+      async delete(this: IHookFunctions): Promise<boolean> {
+        const webhookData = this.getWorkflowStaticData('node');
+        const credentials = await this.getCredentials('GateKitApi');
+        const projectId = this.getNodeParameter('projectId') as string;
+
+        if (!projectId) {
+          throw new Error('Project ID is required');
+        }
+
+        if (webhookData.webhookId === undefined) {
+          return true;
+        }
+
+        const apiUrl = credentials.apiUrl as string;
+
+        try {
+          await this.helpers.request({
+            method: 'DELETE',
+            url: \`\${apiUrl}/api/v1/projects/\${projectId}/webhooks/\${webhookData.webhookId}\`,
+            headers: {
+              'X-API-Key': credentials.apiKey as string,
+            },
+            json: true,
+          });
+
+          delete webhookData.webhookId;
+          delete webhookData.webhookSecret;
+          delete webhookData.events;
+
+          return true;
+        } catch (error: any) {
+          // Webhook might already be deleted
+          if (error.statusCode === 404 || error.response?.status === 404) {
+            delete webhookData.webhookId;
+            delete webhookData.webhookSecret;
+            delete webhookData.events;
+            return true;
+          }
+          throw error;
+        }
+      },
+    },
+  };
+
+  async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+    const bodyData = this.getBodyData();
+    const headers = this.getHeaderData();
+
+    // Validate HMAC signature for security (GateKit format: sha256=<hash>)
+    const webhookData = this.getWorkflowStaticData('node');
+    const signatureHeader = headers['x-gatekit-signature'] as string;
+    const timestamp = headers['x-gatekit-timestamp'] as string;
+
+    // If we have a secret stored, signature validation is required
+    if (webhookData.webhookSecret) {
+      if (!signatureHeader || !timestamp) {
+        throw new Error('Missing webhook signature or timestamp');
+      }
+
+      const crypto = require('crypto');
+
+      // GateKit signature format: timestamp.body
+      const signedPayload = \`\${timestamp}.\${JSON.stringify(bodyData)}\`;
+      const expectedSignature = crypto
+        .createHmac('sha256', webhookData.webhookSecret)
+        .update(signedPayload)
+        .digest('hex');
+
+      // Extract signature (format: "sha256=<hash>")
+      const signature = signatureHeader.replace('sha256=', '');
+
+      if (signature !== expectedSignature) {
+        throw new Error('Invalid webhook signature - possible security attack');
+      }
+    }
+
+    // Process the webhook payload from GateKit
+    // The payload structure depends on the event type
+    return {
+      workflowData: [this.helpers.returnJsonArray([bodyData])],
+    };
+  }
+}
+`;
   }
 
   private generateNodeFile(contracts: ExtractedContract[]): string {
@@ -327,7 +585,10 @@ export class GateKitApi implements ICredentialType {
         n8n: {
           n8nNodesApiVersion: 1,
           credentials: ['dist/credentials/GateKitApi.credentials.js'],
-          nodes: ['dist/nodes/GateKit/GateKit.node.js'],
+          nodes: [
+            'dist/nodes/GateKit/GateKit.node.js',
+            'dist/nodes/GateKitTrigger/GateKitTrigger.node.js',
+          ],
         },
         devDependencies: {
           '@types/node': '^24.6.2',
@@ -348,6 +609,7 @@ export class GateKitApi implements ICredentialType {
 
   private generateIndexFile(): string {
     return `export * from './dist/nodes/GateKit/GateKit.node';
+export * from './dist/nodes/GateKitTrigger/GateKitTrigger.node';
 export * from './dist/credentials/GateKitApi.credentials';
 `;
   }
@@ -412,9 +674,11 @@ export * from './dist/credentials/GateKitApi.credentials';
 
       // Create directory structure
       const nodesDir = path.join(outputDir, 'nodes', 'GateKit');
+      const triggerNodesDir = path.join(outputDir, 'nodes', 'GateKitTrigger');
       const credentialsDir = path.join(outputDir, 'credentials');
 
       await fs.mkdir(nodesDir, { recursive: true });
+      await fs.mkdir(triggerNodesDir, { recursive: true });
       await fs.mkdir(credentialsDir, { recursive: true });
 
       // Write generated n8n node files
@@ -425,6 +689,14 @@ export * from './dist/credentials/GateKitApi.credentials';
           this.generateNodeCodex(),
         ),
         fs.writeFile(
+          path.join(triggerNodesDir, 'GateKitTrigger.node.ts'),
+          n8nNode.triggerNodeFile,
+        ),
+        fs.writeFile(
+          path.join(triggerNodesDir, 'GateKitTrigger.node.json'),
+          this.generateTriggerNodeCodex(),
+        ),
+        fs.writeFile(
           path.join(credentialsDir, 'GateKitApi.credentials.ts'),
           n8nNode.credentialsFile,
         ),
@@ -432,6 +704,7 @@ export * from './dist/credentials/GateKitApi.credentials';
         fs.writeFile(path.join(outputDir, 'gulpfile.js'), n8nNode.gulpfile),
         fs.writeFile(path.join(outputDir, 'index.ts'), n8nNode.indexFile),
         this.copyGateKitIcon(outputDir),
+        this.copyGateKitIconToTrigger(outputDir),
       ]);
     } catch (error) {
       throw new Error(
@@ -465,6 +738,31 @@ export * from './dist/credentials/GateKitApi.credentials';
     );
   }
 
+  private generateTriggerNodeCodex(): string {
+    return JSON.stringify(
+      {
+        node: 'n8n-nodes-gatekit.GateKitTrigger',
+        nodeVersion: '1.0',
+        codexVersion: '1.0',
+        categories: ['Communication', 'Trigger'],
+        resources: {
+          credentialDocumentation: [
+            {
+              url: 'https://docs.gatekit.dev/authentication',
+            },
+          ],
+          primaryDocumentation: [
+            {
+              url: 'https://docs.gatekit.dev/webhooks',
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    );
+  }
+
   private generateGulpfile(): string {
     return `const { src, dest } = require('gulp');
 
@@ -485,6 +783,23 @@ exports['build:icons'] = copyIcons;
 </svg>`;
 
     const iconPath = path.join(outputDir, 'nodes', 'GateKit', 'gatekit.svg');
+    await fs.writeFile(iconPath, iconSvg);
+  }
+
+  private async copyGateKitIconToTrigger(outputDir: string): Promise<void> {
+    // Create a GateKit Trigger SVG icon with a notification badge
+    const iconSvg = `<svg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg">
+  <rect width="60" height="60" rx="12" fill="#6366f1"/>
+  <text x="30" y="35" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">GK</text>
+  <circle cx="45" cy="15" r="5" fill="#10b981"/>
+</svg>`;
+
+    const iconPath = path.join(
+      outputDir,
+      'nodes',
+      'GateKitTrigger',
+      'gatekit.svg',
+    );
     await fs.writeFile(iconPath, iconSvg);
   }
   private generateOperationsList(contracts: ExtractedContract[]): string {


### PR DESCRIPTION
## Summary

Added **GateKitTrigger** node generation to the main n8n generator, enabling users to receive webhook events and automatically start workflows when messages are received.

## Changes

✅ **Added trigger node generation:**
- `generateTriggerNodeFile()` - Complete trigger node implementation with webhook lifecycle methods
- HMAC SHA-256 signature validation for secure webhook processing  
- Event subscriptions: `message.received`, `message.sent`, `message.failed`
- Auto-registration with GateKit webhook API

✅ **Updated package structure:**
- Single `n8n-nodes-gatekit` package now exports both nodes
- `GateKit.node.js` - Action node (send messages, manage projects)
- `GateKitTrigger.node.js` - Trigger node (receive webhooks, start workflows)
- Shared `GateKitApi` credentials

✅ **Added trigger node UI:**
- Custom icon with notification badge
- n8n codex metadata for marketplace

## Benefits

- 🎯 **Single package install** - Users get both action + trigger nodes in one package
- 🔒 **Secure webhooks** - HMAC validation prevents unauthorized webhook calls
- 🚀 **Auto-start workflows** - Triggers execute workflows when messages arrive
- 🧹 **Simpler architecture** - One generator for all n8n nodes

## Test Plan

- [x] Generator compiles trigger node successfully
- [x] Both nodes export correctly in package.json
- [x] TypeScript compilation passes
- [x] Gulp icon copy works for both nodes
- [ ] Manual test: Install in n8n and verify both nodes appear
- [ ] Manual test: Configure trigger and verify webhook registration
- [ ] Manual test: Send webhook and verify HMAC validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)