### PR TITLE
feat: implement project invitation system

### DIFF
--- a/prisma/migrations/20251005180220_add_invites_table/migration.sql
+++ b/prisma/migrations/20251005180220_add_invites_table/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "invites" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "project_id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "invites_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "invites_token_key" ON "invites"("token");
+
+-- CreateIndex
+CREATE INDEX "invites_email_idx" ON "invites"("email");
+
+-- CreateIndex
+CREATE INDEX "invites_token_idx" ON "invites"("token");
+
+-- CreateIndex
+CREATE INDEX "invites_expires_at_idx" ON "invites"("expires_at");
+
+-- AddForeignKey
+ALTER TABLE "invites" ADD CONSTRAINT "invites_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,6 +74,7 @@ model Project {
 
   // New sharing relationships
   members          ProjectMember[]
+  invites          Invite[]
 
   // Identity relationships
   identities       Identity[]
@@ -97,6 +98,22 @@ model ProjectMember {
   @@unique([projectId, userId])
   @@index([userId])
   @@map("project_members")
+}
+
+model Invite {
+  id        String   @id @default(uuid())
+  email     String
+  projectId String   @map("project_id")
+  token     String   @unique
+  expiresAt DateTime @map("expires_at")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  project   Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([email])
+  @@index([token])
+  @@index([expiresAt])
+  @@map("invites")
 }
 
 model ApiKey {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -12,6 +12,7 @@ import { Public } from '../common/decorators/public.decorator';
 import { PermissionResponse } from './dto/permission-response.dto';
 import { SignupDto } from './dto/signup.dto';
 import { LoginDto } from './dto/login.dto';
+import { AcceptInviteDto } from './dto/accept-invite.dto';
 import { AuthResponse } from './dto/auth-response';
 import { LocalAuthService } from './local-auth.service';
 
@@ -113,6 +114,48 @@ export class AuthController {
   })
   async login(@Body() loginDto: LoginDto): Promise<AuthResponse> {
     return this.localAuthService.login(loginDto);
+  }
+
+  @Post('accept-invite')
+  @Public()
+  @SdkContract({
+    command: 'auth accept-invite',
+    description: 'Accept a project invitation and create account',
+    category: 'Auth',
+    requiredScopes: [],
+    inputType: 'AcceptInviteDto',
+    outputType: 'AuthResponse',
+    options: {
+      token: {
+        required: true,
+        description: 'Invite token from invitation link',
+        type: 'string',
+      },
+      name: {
+        required: true,
+        description: 'Full name',
+        type: 'string',
+      },
+      password: {
+        required: true,
+        description: 'Password (min 8 chars, 1 uppercase, 1 number)',
+        type: 'string',
+      },
+    },
+    examples: [
+      {
+        description: 'Accept invitation',
+        command:
+          'gatekit auth accept-invite --token abc123... --name "John Doe" --password SecurePass123',
+      },
+    ],
+  })
+  async acceptInvite(@Body() dto: AcceptInviteDto): Promise<AuthResponse> {
+    return this.localAuthService.acceptInvite(
+      dto.token,
+      dto.name,
+      dto.password,
+    );
   }
 
   @Get('whoami')

--- a/src/auth/dto/accept-invite.dto.ts
+++ b/src/auth/dto/accept-invite.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, MinLength, Matches } from 'class-validator';
+
+export class AcceptInviteDto {
+  @IsString()
+  token: string;
+
+  @IsString()
+  @MinLength(1)
+  name: string;
+
+  @IsString()
+  @MinLength(8, { message: 'Password must be at least 8 characters long' })
+  @Matches(/[A-Z]/, {
+    message: 'Password must contain at least one uppercase letter',
+  })
+  @Matches(/[0-9]/, { message: 'Password must contain at least one number' })
+  password: string;
+}

--- a/src/auth/local-auth-invite.service.spec.ts
+++ b/src/auth/local-auth-invite.service.spec.ts
@@ -1,0 +1,241 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LocalAuthService } from './local-auth.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { UnauthorizedException, ConflictException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+
+jest.mock('bcrypt');
+
+describe('LocalAuthService - Accept Invite', () => {
+  let service: LocalAuthService;
+  let prisma: PrismaService;
+
+  const mockPrisma = {
+    invite: {
+      findUnique: jest.fn(),
+      delete: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+    projectMember: {
+      create: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+
+  const mockJwtService = {
+    sign: jest.fn().mockReturnValue('mock-jwt-token'),
+  };
+
+  const mockConfigService = {
+    get: jest.fn().mockReturnValue('test-jwt-secret'),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LocalAuthService,
+        {
+          provide: PrismaService,
+          useValue: mockPrisma,
+        },
+        {
+          provide: JwtService,
+          useValue: mockJwtService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<LocalAuthService>(LocalAuthService);
+    prisma = module.get<PrismaService>(PrismaService);
+
+    jest.clearAllMocks();
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
+  });
+
+  describe('acceptInvite', () => {
+    const validToken = 'valid-token-123';
+    const validInvite = {
+      id: 'invite-id',
+      email: 'newuser@example.com',
+      projectId: 'test-project',
+      token: validToken,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours from now
+      project: {
+        id: 'test-project',
+        name: 'Test Project',
+      },
+    };
+
+    it('should throw UnauthorizedException if invite not found', async () => {
+      mockPrisma.invite.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.acceptInvite('invalid-token', 'John Doe', 'Password123'),
+      ).rejects.toThrow(UnauthorizedException);
+      expect(mockPrisma.invite.findUnique).toHaveBeenCalledWith({
+        where: { token: 'invalid-token' },
+        include: { project: true },
+      });
+    });
+
+    it('should throw UnauthorizedException if invite is expired', async () => {
+      const expiredInvite = {
+        ...validInvite,
+        expiresAt: new Date(Date.now() - 1000), // 1 second ago
+      };
+
+      mockPrisma.invite.findUnique.mockResolvedValue(expiredInvite);
+      mockPrisma.invite.delete.mockResolvedValue(expiredInvite);
+
+      await expect(
+        service.acceptInvite(validToken, 'John Doe', 'Password123'),
+      ).rejects.toThrow(UnauthorizedException);
+      expect(mockPrisma.invite.delete).toHaveBeenCalledWith({
+        where: { token: validToken },
+      });
+    });
+
+    it('should throw ConflictException if user already exists', async () => {
+      const existingUser = {
+        id: 'existing-user-id',
+        email: 'newuser@example.com',
+      };
+
+      mockPrisma.invite.findUnique.mockResolvedValue(validInvite);
+      mockPrisma.user.findUnique.mockResolvedValue(existingUser);
+
+      await expect(
+        service.acceptInvite(validToken, 'John Doe', 'Password123'),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should create user and add to project successfully', async () => {
+      const newUser = {
+        id: 'new-user-id',
+        email: 'newuser@example.com',
+        name: 'John Doe',
+        passwordHash: 'hashed-password',
+        isAdmin: false,
+      };
+
+      mockPrisma.invite.findUnique.mockResolvedValue(validInvite);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.$transaction.mockImplementation(async (callback) => {
+        return callback({
+          user: {
+            create: jest.fn().mockResolvedValue(newUser),
+          },
+          projectMember: {
+            create: jest.fn().mockResolvedValue({
+              projectId: 'test-project',
+              userId: 'new-user-id',
+              role: 'member',
+            }),
+          },
+          invite: {
+            delete: jest.fn().mockResolvedValue(validInvite),
+          },
+        });
+      });
+
+      const result = await service.acceptInvite(
+        validToken,
+        'John Doe',
+        'Password123',
+      );
+
+      expect(result).toEqual({
+        accessToken: 'mock-jwt-token',
+        user: {
+          id: 'new-user-id',
+          email: 'newuser@example.com',
+          name: 'John Doe',
+          isAdmin: false,
+        },
+      });
+      expect(bcrypt.hash).toHaveBeenCalledWith('Password123', 10);
+    });
+
+    it('should hash password with correct salt rounds', async () => {
+      const newUser = {
+        id: 'new-user-id',
+        email: 'newuser@example.com',
+        name: 'John Doe',
+        passwordHash: 'hashed-password',
+        isAdmin: false,
+      };
+
+      mockPrisma.invite.findUnique.mockResolvedValue(validInvite);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.$transaction.mockImplementation(async (callback) => {
+        return callback({
+          user: {
+            create: jest.fn().mockResolvedValue(newUser),
+          },
+          projectMember: {
+            create: jest.fn().mockResolvedValue({
+              projectId: 'test-project',
+              userId: 'new-user-id',
+              role: 'member',
+            }),
+          },
+          invite: {
+            delete: jest.fn().mockResolvedValue(validInvite),
+          },
+        });
+      });
+
+      await service.acceptInvite(validToken, 'John Doe', 'SecurePass123');
+
+      expect(bcrypt.hash).toHaveBeenCalledWith('SecurePass123', 10);
+    });
+
+    it('should create user as non-admin', async () => {
+      const newUser = {
+        id: 'new-user-id',
+        email: 'newuser@example.com',
+        name: 'John Doe',
+        passwordHash: 'hashed-password',
+        isAdmin: false,
+      };
+
+      let capturedUserData: any;
+
+      mockPrisma.invite.findUnique.mockResolvedValue(validInvite);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.$transaction.mockImplementation(async (callback) => {
+        return callback({
+          user: {
+            create: jest.fn().mockImplementation((data) => {
+              capturedUserData = data.data;
+              return Promise.resolve(newUser);
+            }),
+          },
+          projectMember: {
+            create: jest.fn().mockResolvedValue({
+              projectId: 'test-project',
+              userId: 'new-user-id',
+              role: 'member',
+            }),
+          },
+          invite: {
+            delete: jest.fn().mockResolvedValue(validInvite),
+          },
+        });
+      });
+
+      await service.acceptInvite(validToken, 'John Doe', 'Password123');
+
+      expect(capturedUserData.isAdmin).toBe(false);
+    });
+  });
+});

--- a/src/members/dto/create-invite.dto.ts
+++ b/src/members/dto/create-invite.dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator';
+
+export class CreateInviteDto {
+  @IsEmail()
+  email: string;
+}

--- a/src/members/dto/invite-response.dto.ts
+++ b/src/members/dto/invite-response.dto.ts
@@ -1,0 +1,5 @@
+export class InviteResponse {
+  inviteLink: string;
+  email: string;
+  expiresAt: Date;
+}

--- a/src/members/members-invite.service.spec.ts
+++ b/src/members/members-invite.service.spec.ts
@@ -1,0 +1,213 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MembersService } from './members.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ProjectRole } from '@prisma/client';
+
+describe('MembersService - Invite System', () => {
+  let service: MembersService;
+  let prisma: PrismaService;
+
+  const mockPrisma = {
+    user: {
+      findUnique: jest.fn(),
+    },
+    project: {
+      findUnique: jest.fn(),
+    },
+    projectMember: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+    invite: {
+      create: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MembersService,
+        {
+          provide: PrismaService,
+          useValue: mockPrisma,
+        },
+      ],
+    }).compile();
+
+    service = module.get<MembersService>(MembersService);
+    prisma = module.get<PrismaService>(PrismaService);
+
+    jest.clearAllMocks();
+  });
+
+  describe('createInvite', () => {
+    const projectId = 'test-project';
+    const requesterId = 'requester-id';
+    const baseUrl = 'https://app.example.com';
+
+    it('should throw NotFoundException if requester has no access', async () => {
+      mockPrisma.project.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.createInvite(
+          projectId,
+          'user@example.com',
+          requesterId,
+          baseUrl,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException if user is already a member', async () => {
+      const mockProject = {
+        id: projectId,
+        ownerId: requesterId,
+        members: [],
+      };
+
+      const mockExistingUser = {
+        id: 'existing-user-id',
+        email: 'user@example.com',
+      };
+
+      const mockExistingMember = {
+        projectId,
+        userId: 'existing-user-id',
+        role: ProjectRole.member,
+      };
+
+      mockPrisma.project.findUnique.mockResolvedValue(mockProject);
+      mockPrisma.user.findUnique.mockResolvedValue(mockExistingUser);
+      mockPrisma.projectMember.findUnique.mockResolvedValue(mockExistingMember);
+
+      await expect(
+        service.createInvite(
+          projectId,
+          'user@example.com',
+          requesterId,
+          baseUrl,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockPrisma.projectMember.findUnique).toHaveBeenCalledWith({
+        where: {
+          projectId_userId: {
+            projectId,
+            userId: 'existing-user-id',
+          },
+        },
+      });
+    });
+
+    it('should add existing user directly to project', async () => {
+      const mockProject = {
+        id: projectId,
+        ownerId: requesterId,
+        members: [],
+      };
+
+      const mockExistingUser = {
+        id: 'existing-user-id',
+        email: 'user@example.com',
+      };
+
+      mockPrisma.project.findUnique.mockResolvedValue(mockProject);
+      mockPrisma.user.findUnique.mockResolvedValue(mockExistingUser);
+      mockPrisma.projectMember.findUnique.mockResolvedValue(null);
+      mockPrisma.projectMember.create.mockResolvedValue({
+        projectId,
+        userId: 'existing-user-id',
+        role: ProjectRole.member,
+      });
+
+      const result = await service.createInvite(
+        projectId,
+        'user@example.com',
+        requesterId,
+        baseUrl,
+      );
+
+      expect(result.inviteLink).toBeNull();
+      expect(result.email).toBe('user@example.com');
+      expect(result.message).toBe('User added to project successfully');
+      expect(mockPrisma.projectMember.create).toHaveBeenCalledWith({
+        data: {
+          projectId,
+          userId: 'existing-user-id',
+          role: ProjectRole.member,
+        },
+      });
+    });
+
+    it('should create invite for new user', async () => {
+      const mockProject = {
+        id: projectId,
+        ownerId: requesterId,
+        members: [],
+      };
+
+      mockPrisma.project.findUnique.mockResolvedValue(mockProject);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.invite.create.mockResolvedValue({
+        id: 'invite-id',
+        email: 'newuser@example.com',
+        projectId,
+        token: 'generated-token',
+        expiresAt: new Date(),
+      });
+
+      const result = await service.createInvite(
+        projectId,
+        'newuser@example.com',
+        requesterId,
+        baseUrl,
+      );
+
+      expect(result.inviteLink).toContain(baseUrl);
+      expect(result.inviteLink).toContain('/invite/');
+      expect(result.email).toBe('newuser@example.com');
+      expect(result.expiresAt).toBeDefined();
+      expect(mockPrisma.invite.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          email: 'newuser@example.com',
+          projectId,
+          token: expect.any(String),
+          expiresAt: expect.any(Date),
+        }),
+      });
+    });
+
+    it('should allow project members to create invites', async () => {
+      const mockProject = {
+        id: projectId,
+        ownerId: 'different-owner',
+        members: [
+          {
+            userId: requesterId,
+            role: ProjectRole.member,
+          },
+        ],
+      };
+
+      mockPrisma.project.findUnique.mockResolvedValue(mockProject);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.invite.create.mockResolvedValue({
+        id: 'invite-id',
+        email: 'newuser@example.com',
+        projectId,
+        token: 'generated-token',
+        expiresAt: new Date(),
+      });
+
+      const result = await service.createInvite(
+        projectId,
+        'newuser@example.com',
+        requesterId,
+        baseUrl,
+      );
+
+      expect(result.inviteLink).toBeDefined();
+      expect(result.email).toBe('newuser@example.com');
+    });
+  });
+});

--- a/src/members/members.controller.ts
+++ b/src/members/members.controller.ts
@@ -15,6 +15,7 @@ import { RequireScopes } from '../common/decorators/scopes.decorator';
 import { SdkContract } from '../common/decorators/sdk-contract.decorator';
 import { AddMemberDto } from './dto/add-member.dto';
 import { UpdateMemberRoleDto } from './dto/update-member-role.dto';
+import { CreateInviteDto } from './dto/create-invite.dto';
 import { ApiScope } from '../common/enums/api-scopes.enum';
 
 @Controller('api/v1/projects/:project/members')
@@ -167,6 +168,43 @@ export class MembersController {
       project,
       userId,
       req.user.userId,
+    );
+  }
+
+  @Post('invite')
+  @RequireScopes(ApiScope.MEMBERS_WRITE)
+  @SdkContract({
+    command: 'members invite',
+    description: 'Invite a user to join a project',
+    category: 'Members',
+    requiredScopes: [ApiScope.MEMBERS_WRITE],
+    inputType: 'CreateInviteDto',
+    outputType: 'InviteResponse',
+    options: {
+      email: {
+        required: true,
+        description: 'Email address of user to invite',
+        type: 'string',
+      },
+    },
+    examples: [
+      {
+        description: 'Invite a user to project',
+        command: 'gatekit members invite my-project --email user@example.com',
+      },
+    ],
+  })
+  async inviteMember(
+    @Param('project') project: string,
+    @Body() dto: CreateInviteDto,
+    @Request() req: any,
+  ) {
+    const baseUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
+    return this.membersService.createInvite(
+      project,
+      dto.email,
+      req.user.userId,
+      baseUrl,
     );
   }
 }


### PR DESCRIPTION
## Summary
Implemented token-based project invitation system that allows owners/members to invite new users without requiring an email service. System intelligently handles both existing and new users.

## Features

### Smart Invite Logic
- **Existing users**: Automatically added to project (no invite token needed)
- **New users**: Secure invite link with 24-hour expiration
- **No email service required**: Owner manually shares invite links

### API Endpoints
- `POST /api/v1/projects/{project}/members/invite` - Create invite
- `POST /api/v1/auth/accept-invite` - Accept invite and create account

### Database Changes
- Added `Invite` model with secure token, email, projectId, and expiry
- Cascading delete when project is removed
- Automatic cleanup of expired invites

### Security Features
- Cryptographically secure random tokens (32 bytes hex)
- Password validation (min 8 chars, 1 uppercase, 1 number)
- Project access validation (members can invite)
- Duplicate member prevention
- Transaction-safe user creation + membership

## Example Flow

```bash
# 1. Owner creates invite
POST /api/v1/projects/my-project/members/invite
{ "email": "user@example.com" }

Response:
{
  "inviteLink": "https://app.gatekit.dev/invite/abc123...",
  "email": "user@example.com",
  "expiresAt": "2025-01-10T12:00:00Z"
}

# 2. Owner shares link (Slack, WhatsApp, etc.)

# 3. User accepts invite
POST /api/v1/auth/accept-invite
{
  "token": "abc123...",
  "name": "John Doe",
  "password": "SecurePass123"
}

Response:
{
  "accessToken": "jwt...",
  "user": { ... }
}
```

## Testing
- ✅ 11 new tests covering invite creation and acceptance
- ✅ 702 total tests passing
- ✅ Complete coverage of edge cases (expired tokens, duplicate users, etc.)

## Implementation Details
- Users created via invite are non-admin by default
- Invite tokens expire after 24 hours
- Failed acceptance attempts auto-delete expired invites
- SDK contracts updated for CLI generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)