### PR TITLE
feat: add setupRequired and version to health endpoint

### DIFF
--- a/src/health/health.service.spec.ts
+++ b/src/health/health.service.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthService } from './health.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('HealthService', () => {
+  let service: HealthService;
+  let prisma: PrismaService;
+
+  const mockPrisma = {
+    user: {
+      count: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HealthService,
+        {
+          provide: PrismaService,
+          useValue: mockPrisma,
+        },
+      ],
+    }).compile();
+
+    service = module.get<HealthService>(HealthService);
+    prisma = module.get<PrismaService>(PrismaService);
+
+    jest.clearAllMocks();
+  });
+
+  describe('check', () => {
+    it('should return healthy status with setupRequired true when no users exist', async () => {
+      mockPrisma.user.count.mockResolvedValue(0);
+
+      const result = await service.check();
+
+      expect(result.status).toBe('healthy');
+      expect(result.setupRequired).toBe(true);
+      expect(result.version).toBeDefined();
+      expect(result.timestamp).toBeDefined();
+      expect(mockPrisma.user.count).toHaveBeenCalledWith({
+        where: {
+          passwordHash: {
+            not: null,
+          },
+        },
+      });
+    });
+
+    it('should return healthy status with setupRequired false when users exist', async () => {
+      mockPrisma.user.count.mockResolvedValue(1);
+
+      const result = await service.check();
+
+      expect(result.status).toBe('healthy');
+      expect(result.setupRequired).toBe(false);
+      expect(result.version).toBeDefined();
+      expect(result.timestamp).toBeDefined();
+    });
+
+    it('should return setupRequired false when multiple users exist', async () => {
+      mockPrisma.user.count.mockResolvedValue(5);
+
+      const result = await service.check();
+
+      expect(result.setupRequired).toBe(false);
+    });
+
+    it('should only count users with passwordHash set', async () => {
+      mockPrisma.user.count.mockResolvedValue(0);
+
+      await service.check();
+
+      expect(mockPrisma.user.count).toHaveBeenCalledWith({
+        where: {
+          passwordHash: {
+            not: null,
+          },
+        },
+      });
+    });
+  });
+});

--- a/src/health/health.service.ts
+++ b/src/health/health.service.ts
@@ -1,18 +1,28 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import * as packageJson from '../../package.json';
 
 @Injectable()
 export class HealthService {
-  check() {
+  constructor(private prisma: PrismaService) {}
+
+  async check() {
+    // Check if any user with password exists (setup complete check)
+    const userCount = await this.prisma.user.count({
+      where: {
+        passwordHash: {
+          not: null,
+        },
+      },
+    });
+
+    const setupRequired = userCount === 0;
+
     return {
-      success: true,
-      data: {
-        status: 'healthy',
-        timestamp: new Date().toISOString(),
-      },
-      metadata: {
-        timestamp: new Date().toISOString(),
-        version: 'v1',
-      },
+      status: 'healthy',
+      version: packageJson.version,
+      setupRequired,
+      timestamp: new Date().toISOString(),
     };
   }
 }

--- a/test/integration/app.e2e-spec.ts
+++ b/test/integration/app.e2e-spec.ts
@@ -72,8 +72,10 @@ describe('GateKit API (e2e)', () => {
         .get('/api/v1/health')
         .expect(200)
         .expect((res) => {
-          expect(res.body).toHaveProperty('success', true);
-          expect(res.body.data).toHaveProperty('status', 'healthy');
+          expect(res.body.status).toBe('healthy');
+          expect(res.body.version).toBeDefined();
+          expect(typeof res.body.setupRequired).toBe('boolean');
+          expect(res.body.timestamp).toBeDefined();
         });
     });
   });

--- a/test/integration/auth0.e2e-spec.ts
+++ b/test/integration/auth0.e2e-spec.ts
@@ -152,7 +152,10 @@ describe('Auth0 Authentication (e2e)', () => {
         .get('/api/v1/health')
         .expect(200)
         .expect((res) => {
-          expect(res.body.data.status).toBe('healthy');
+          expect(res.body.status).toBe('healthy');
+          expect(res.body.version).toBeDefined();
+          expect(typeof res.body.setupRequired).toBe('boolean');
+          expect(res.body.timestamp).toBeDefined();
         });
     });
 
@@ -162,7 +165,8 @@ describe('Auth0 Authentication (e2e)', () => {
         .set('Authorization', 'Bearer fake.jwt.token')
         .expect(200)
         .expect((res) => {
-          expect(res.body.data.status).toBe('healthy');
+          expect(res.body.status).toBe('healthy');
+          expect(res.body.version).toBeDefined();
         });
     });
 
@@ -172,7 +176,8 @@ describe('Auth0 Authentication (e2e)', () => {
         .set('X-API-Key', 'any-key')
         .expect(200)
         .expect((res) => {
-          expect(res.body.data.status).toBe('healthy');
+          expect(res.body.status).toBe('healthy');
+          expect(res.body.version).toBeDefined();
         });
     });
   });


### PR DESCRIPTION
## Summary

Adds onboarding detection and version reporting to health endpoint.

## Changes

**New Response Format** (simplified, flat structure):
```json
{
  "status": "healthy",
  "version": "1.3.2",
  "setupRequired": true,
  "timestamp": "2025-01-05T..."
}
```

**Old Format** (removed):
```json
{
  "success": true,
  "data": { "status": "healthy", ... },
  "metadata": { "version": "v1", ... }
}
```

## Features

✅ **setupRequired flag** - Enables frontend to show onboarding vs login
  - `true` → No users exist (fresh install, show signup)
  - `false` → Users exist (setup complete, show login)

✅ **Version reporting** - Package version from package.json (1.3.2)

✅ **Simplified structure** - Flat, no nested data/metadata confusion

## Breaking Change

⚠️ Health endpoint response structure changed from nested to flat format.

Frontend code needs update:
```diff
- if (health.data.status === 'healthy')
+ if (health.status === 'healthy')

- const version = health.metadata.version
+ const version = health.version
```

## Test Coverage

- ✅ setupRequired true when no users
- ✅ setupRequired false when users exist  
- ✅ Version field present
- ✅ Only counts users with passwordHash

## Use Case

```typescript
const health = await fetch('/api/v1/health');
if (health.setupRequired) {
  router.push('/onboarding');  // Show signup
} else {
  router.push('/login');  // Show login
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)