### PR TITLE
fix: use workspace SDK dependency to prevent version staleness

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,9 @@
     ],
     "*": [
       "bash -c 'npm test'",
-      "bash -c 'npm run test:e2e'"
+      "bash -c 'npm run test:e2e'",
+      "bash -c 'npm run generate:all'",
+      "bash -c 'npm run build'"
     ]
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "extract:contracts": "ts-node -r tsconfig-paths/register tools/extract-contracts.ts",
     "generate:all": "npm run extract:contracts && npm run validate:contracts:types && npm run generate:sdk && npm run generate:cli && npm run generate:n8n && npm run generate:openapi && npm run validate:generated",
-    "validate:generated": "cd generated/sdk && npm install && npm run build && npm pack && cd ../cli && npm install ../sdk/gatekit-sdk-*.tgz && npm run build && cd ../n8n && npm install && npm run build && echo '✅ Generated packages validation completed'",
+    "validate:generated": "cd generated/sdk && npm install && npm run build && cd ../cli && npm install && npm run build && cd ../n8n && npm install && npm run build && echo '✅ Generated packages validation completed'",
     "validate:contracts:types": "ts-node -r tsconfig-paths/register tools/scripts/validate-contracts.ts",
     "generate:sdk": "ts-node -r tsconfig-paths/register tools/generators/sdk-generator.ts",
     "generate:cli": "ts-node -r tsconfig-paths/register tools/generators/cli-generator.ts",

--- a/tools/generators/cli-generator.ts
+++ b/tools/generators/cli-generator.ts
@@ -764,7 +764,7 @@ export function handleError(error: any): void {
           prepublishOnly: 'npm run build',
         },
         dependencies: {
-          '@gatekit/sdk': 'latest',
+          '@gatekit/sdk': 'file:../sdk',
           commander: '^14.0.1',
           axios: '^1.12.2',
         },

--- a/tools/generators/templates/cli/.github/workflows/publish.yml
+++ b/tools/generators/templates/cli/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get package version
         id: pkg_version
-        run: echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+        run: echo "VERSION=$(node -p 'require("./package.json").version')" >> $GITHUB_OUTPUT
 
       - name: Replace SDK file reference with npm version
         run: |

--- a/tools/generators/templates/cli/.github/workflows/publish.yml
+++ b/tools/generators/templates/cli/.github/workflows/publish.yml
@@ -20,6 +20,16 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Get package version
+        id: pkg_version
+        run: echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Replace SDK file reference with npm version
+        run: |
+          # Replace "file:../sdk" with actual version for publishing
+          sed -i 's|"@gatekit/sdk": "file:../sdk"|"@gatekit/sdk": "^${{ steps.pkg_version.outputs.VERSION }}"|g' package.json
+          echo "✅ Updated SDK dependency to version ^${{ steps.pkg_version.outputs.VERSION }}"
+
       - name: Install dependencies
         run: npm install
 


### PR DESCRIPTION
## Summary

Fixes the SDK version staleness issue that was causing CLI TypeScript compilation errors. The pre-commit hooks were correctly catching this bug!

## Problem

- CLI's `package.json` was hardcoded to use specific SDK tarball (e.g., `gatekit-sdk-1.3.2.tgz`)
- When backend version bumped to 1.4.0, CLI still referenced old 1.3.2 SDK
- New SDK methods (like `updateProfile`) were missing, causing TypeScript errors
- Pre-commit build step correctly blocked commits with this issue

## Root Cause

The `validate:generated` script was:
1. Running `npm pack` on SDK (creates `gatekit-sdk-x.y.z.tgz`)
2. Running `npm install ../sdk/gatekit-sdk-*.tgz` in CLI
3. This updated CLI's `package.json` to reference specific tarball
4. Tarball path would become stale when version changed

## Solution

### Local Development (Backend Repo)
- CLI generator now uses `"@gatekit/sdk": "file:../sdk"` instead of `"latest"`
- Workspace-style dependency always uses current local SDK
- No version staleness possible
- Pre-commit hooks work correctly

### Publishing (CLI Repo)
- Added workflow step to replace `file:../sdk` with `^x.y.z` before `npm install`
- Published CLI package references correct npm version
- Version coordination maintained

### Pre-commit Hooks
- ✅ Run all tests (unit + e2e)
- ✅ Regenerate all packages (`npm run generate:all`)
- ✅ Build project (`npm run build`)
- Catches issues like this before they're committed

## Changes

1. **CLI Generator** (`tools/generators/cli-generator.ts`)
   - Changed SDK dependency from `'latest'` to `'file:../sdk'`

2. **Validate Script** (`package.json`)
   - Removed `npm pack` and tarball installation
   - Direct workspace dependency resolution

3. **CLI Publish Workflow** (`tools/generators/templates/cli/.github/workflows/publish.yml`)
   - Added step to replace `file:../sdk` with `^{version}` before publishing
   - Ensures published package has correct npm dependency

4. **Pre-commit Hooks** (`package.json`)
   - Re-added `npm run generate:all` and `npm run build`
   - Now safe with workspace dependencies

## Test Plan

- [x] Generate all packages successfully
- [x] CLI builds without TypeScript errors
- [x] Pre-commit hooks run all steps (tests, generation, build)
- [x] Backend build succeeds
- [x] Verified workspace dependency resolution works

🤖 Generated with [Claude Code](https://claude.com/claude-code)